### PR TITLE
Reduced Chunking size for model-levels-to-zarr.

### DIFF
--- a/src/arco_era5/pangeo.py
+++ b/src/arco_era5/pangeo.py
@@ -88,7 +88,7 @@ def run(make_path: t.Callable[..., str], date_range: t.List[datetime.datetime],
 
     recipe = XarrayZarrRecipe(pattern,
                               storage_config=storage_config,
-                              target_chunks={'time': 1},
+                              target_chunks={'time': 1, 'hybrid': 1},
                               subset_inputs=parsed_args.subset_inputs,
                               copy_input_to_local_file=True,
                               cache_inputs=False,


### PR DESCRIPTION
In response to Issue https://github.com/google-research/arco-era5/issues/28, where it was identified that the chunk size in the model-level Zarr data was excessively large, I have made significant improvements. The existing chunk size was in the order of gigabytes. To address this, I introduced a modification in the `target_chunks` method of the `XarrayZarrRecipe`.

By incorporating the `hybrid: 1` parameter in the `target_chunks` method, I was able to split each chunk per level.