### PR TITLE
`level` change in the example of weather-sp.

### DIFF
--- a/raw/README.md
+++ b/raw/README.md
@@ -91,7 +91,7 @@ _Steps_:
    ```shell
    export DATASET=soil
    weather-sp --input-pattern "gs://gcp-public-data-arco-era5/raw/ERA5GRIB/HRES/Month/**/*_hres_$DATASET.grb2" \
-     --output-template "gs://gcp-public-data-arco-era5/raw/ERA5GRIB/HRES/Month/{1}/{0}.grb2_{level}_{shortName}.grib" \
+     --output-template "gs://gcp-public-data-arco-era5/raw/ERA5GRIB/HRES/Month/{1}/{0}.grb2_{typeOfLevel}_{shortName}.grib" \
      --dry-run
    ```
 2. Execute the data split on your
@@ -105,7 +105,7 @@ _Steps_:
    export REGION=us-central1
 
    weather-sp --input-pattern "gs://gcp-public-data-arco-era5/raw/ERA5GRIB/HRES/Month/**/*_hres_$DATASET.grb2" \
-     --output-template "gs://gcp-public-data-arco-era5/raw/ERA5GRIB/HRES/Month/{1}/{0}.grb2_{level}_{shortName}.grib" \
+     --output-template "gs://gcp-public-data-arco-era5/raw/ERA5GRIB/HRES/Month/{1}/{0}.grb2_{typeOfLevel}_{shortName}.grib" \
      --runner DataflowRunner \
      --project $PROJECT \
      --region $REGION \

--- a/raw/era5_ml_lnsp.cfg
+++ b/raw/era5_ml_lnsp.cfg
@@ -1,0 +1,45 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+[parameters]
+client=cds
+dataset=reanalysis-era5-complete
+target_path=gs://gcp-public-data-arco-era5/raw/ERA5GRIB/HRES/Month/{year}/{year}{month:02d}_hres_lnsp.grb2
+partition_keys=
+    year
+    month
+
+# API Keys go here...
+# See these docs: https://weather-tools.readthedocs.io/en/latest/Configuration.html#subsections
+
+[selection]
+class=ea
+stream=oper
+expver=1
+type=an
+levtype=ml
+levelist=1
+year=1979/to/2023
+month=01/to/12
+day=all
+time=00/to/23
+# -------------------------------------------|------------|-----------------------|-----------------------------------------------------
+# name                                       | short name | units                 | docs
+# -------------------------------------------|------------|-----------------------|-----------------------------------------------------
+# Logarithm of surface pressure              | lnsp       | Numeric               | https://apps.ecmwf.int/codes/grib/param-db?id=152
+# -------------------------------------------|------------|-----------------------|-----------------------------------------------------
+param=152.128
+
+
+
+

--- a/raw/era5_ml_zs.cfg
+++ b/raw/era5_ml_zs.cfg
@@ -1,0 +1,44 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+[parameters]
+client=cds
+dataset=reanalysis-era5-complete
+target_path=gs://gcp-public-data-arco-era5/raw/ERA5GRIB/HRES/Month/{year}/{year}{month:02d}_hres_z.grb2
+partition_keys=
+    year
+    month
+
+# API Keys go here...
+# See these docs: https://weather-tools.readthedocs.io/en/latest/Configuration.html#subsections
+
+[selection]
+class=ea
+stream=oper
+expver=1
+type=an
+levtype=ml
+levelist=1
+year=1979/to/2023
+month=01/to/12
+day=all
+time=00/to/23
+# ------------------------------|------------|----------|--------------------------------------------------
+# name                          | short name | units    | docs
+# ------------------------------|------------|----------|--------------------------------------------------
+# Geopotential                  | z          | m^2 s^-2 | https://apps.ecmwf.int/codes/grib/param-db?id=129
+# ------------------------------|------------|----------|--------------------------------------------------
+param=129.128
+
+
+

--- a/raw/era5_ml_zs.cfg
+++ b/raw/era5_ml_zs.cfg
@@ -14,7 +14,7 @@
 [parameters]
 client=cds
 dataset=reanalysis-era5-complete
-target_path=gs://gcp-public-data-arco-era5/raw/ERA5GRIB/HRES/Month/{year}/{year}{month:02d}_hres_z.grb2
+target_path=gs://gcp-public-data-arco-era5/raw/ERA5GRIB/HRES/Month/{year}/{year}{month:02d}_hres_zs.grb2
 partition_keys=
     year
     month


### PR DESCRIPTION
In the [Readme.md](https://github.com/google-research/arco-era5/blob/main/raw/README.md) file of the raw directory, the example for `weather-sp` includes an attribute called `level`. However, upon examining the existing data( one of the  example : gs://gcp-public-data-arco-era5/raw/ERA5GRIB/HRES/Month/2021/202112_hres_soil.grb2), I found that the correct attribute is `typeOfLevel`. This PR updates the attribute name to `typeOfLevel` in the example to reflect the accurate data structure.