### PR TITLE
`level` change in the example of weather-sp.

### DIFF
--- a/raw/README.md
+++ b/raw/README.md
@@ -91,7 +91,7 @@ _Steps_:
    ```shell
    export DATASET=soil
    weather-sp --input-pattern "gs://gcp-public-data-arco-era5/raw/ERA5GRIB/HRES/Month/**/*_hres_$DATASET.grb2" \
-     --output-template "gs://gcp-public-data-arco-era5/raw/ERA5GRIB/HRES/Month/{1}/{0}.grb2_{level}_{shortName}.grib" \
+     --output-template "gs://gcp-public-data-arco-era5/raw/ERA5GRIB/HRES/Month/{1}/{0}.grb2_{typeOfLevel}_{shortName}.grib" \
      --dry-run
    ```
 2. Execute the data split on your
@@ -105,7 +105,7 @@ _Steps_:
    export REGION=us-central1
 
    weather-sp --input-pattern "gs://gcp-public-data-arco-era5/raw/ERA5GRIB/HRES/Month/**/*_hres_$DATASET.grb2" \
-     --output-template "gs://gcp-public-data-arco-era5/raw/ERA5GRIB/HRES/Month/{1}/{0}.grb2_{level}_{shortName}.grib" \
+     --output-template "gs://gcp-public-data-arco-era5/raw/ERA5GRIB/HRES/Month/{1}/{0}.grb2_{typeOfLevel}_{shortName}.grib" \
      --runner DataflowRunner \
      --project $PROJECT \
      --region $REGION \


### PR DESCRIPTION
In the [Readme.md](https://github.com/google-research/arco-era5/blob/main/raw/README.md) file of the raw directory, the example for `weather-sp` includes an attribute called `level`. However, upon examining the existing data (one of the file: gs://gcp-public-data-arco-era5/raw/ERA5GRIB/HRES/Month/2021/202112_hres_soil.grb2), I found that the correct attribute is **`typeOfLevel`**. This PR updates the attribute name to `typeOfLevel` in the example to reflect the accurate data structure.