### PR TITLE
Eliminating redundant --temp-location flag from examples.

### DIFF
--- a/src/model-levels-to-zarr.py
+++ b/src/model-levels-to-zarr.py
@@ -46,7 +46,6 @@ Examples:
      --runner DataflowRunner \
      --project $PROJECT \
      --region $REGION \
-     --temp_location "gs://$BUCKET/tmp/" \
      --setup_file ./setup.py \
      --disk_size_gb 3600 \
      --machine_type m1-ultramem-40 \
@@ -66,7 +65,6 @@ Examples:
      --runner DataflowRunner \
      --project $PROJECT \
      --region $REGION \
-     --temp_location "gs://$BUCKET/tmp/" \
      --setup_file ./setup.py \
      --disk_size_gb 3600 \
      --machine_type m1-ultramem-40 \

--- a/src/single-levels-to-zarr.py
+++ b/src/single-levels-to-zarr.py
@@ -43,7 +43,6 @@ Examples:
      --runner DataflowRunner \
      --project $PROJECT \
      --region $REGION \
-     --temp_location "gs://$BUCKET/tmp/" \
      --setup_file ./setup.py \
      --disk_size_gb 50 \
      --machine_type n2-highmem-2 \
@@ -65,7 +64,6 @@ Examples:
      --runner DataflowRunner \
      --project $PROJECT \
      --region $REGION \
-     --temp_location "gs://$BUCKET/tmp/" \
      --setup_file ./setup.py \
      --disk_size_gb 50 \
      --machine_type n2-highmem-2 \
@@ -85,7 +83,6 @@ Examples:
      --runner DataflowRunner \
      --project $PROJECT \
      --region $REGION \
-     --temp_location "gs://$BUCKET/tmp/" \
      --setup_file ./setup.py \
      --disk_size_gb 50 \
      --machine_type n2-highmem-2 \


### PR DESCRIPTION
In the context of the [model-level-to-zarr.py](https://github.com/google-research/arco-era5/blob/main/src/model-levels-to-zarr.py) and [single-levels-to-zarr.py](https://github.com/google-research/arco-era5/blob/main/src/single-levels-to-zarr.py) examples, the presence of the `--temp-location` flag serves no functional purpose. Notably, this flag remains unmentioned and unutilized within the fundamental [pangeo.py](https://github.com/google-research/arco-era5/blob/main/src/arco_era5/pangeo.py) script, which forms the basis for both of these files.