### PR TITLE
Data Seeding Scripts For Analysis Ready And Cloud Optimized Dataset

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -120,7 +120,7 @@ setup(
     python_requires='>3.8, <3.11',
     install_requires=[
         'apache_beam[gcp]==2.40.0',
-        'pangeo-forge-recipes==0.10.2',
+        'pangeo-forge-recipes==0.9.1',
         'pandas',
         'gcsfs',
         'cfgrib',

--- a/setup.py
+++ b/setup.py
@@ -120,7 +120,7 @@ setup(
     python_requires='>3.8, <3.11',
     install_requires=[
         'apache_beam[gcp]==2.40.0',
-        'pangeo-forge-recipes==0.9.1',
+        'pangeo-forge-recipes==0.10.2',
         'pandas',
         'gcsfs',
         'cfgrib',

--- a/src/arco_era5/__init__.py
+++ b/src/arco_era5/__init__.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from .source_data import GCP_DIRECTORY,SINGLE_LEVEL_VARIABLES,MULTILEVEL_VARIABLES,PRESSURE_LEVELS_GROUPS, TIME_RESOLUTION_HOURS 
-from .source_data import get_var_attrs_dict, read_multilevel_vars, read_single_level_vars, daily_date_iterator, align_coordinates, parse_arguments
+from .source_data import GCP_DIRECTORY,SINGLE_LEVEL_VARIABLES,MULTILEVEL_VARIABLES,PRESSURE_LEVELS_GROUPS, TIME_RESOLUTION_HOURS, HOURS_PER_DAY 
+from .source_data import get_var_attrs_dict, read_multilevel_vars, read_single_level_vars, daily_date_iterator, align_coordinates, parse_arguments, get_pressure_levels_arg, LoadTemporalDataForDateDoFn
 from .pangeo import run, parse_args
+from .update_ar import UpdateSlice as ARUpdateSlice
+from .update_co import GenerateOffset, UpdateSlice as COUpdateSlice

--- a/src/arco_era5/__init__.py
+++ b/src/arco_era5/__init__.py
@@ -11,8 +11,24 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from .source_data import GCP_DIRECTORY,SINGLE_LEVEL_VARIABLES,MULTILEVEL_VARIABLES,PRESSURE_LEVELS_GROUPS, TIME_RESOLUTION_HOURS, HOURS_PER_DAY 
-from .source_data import get_var_attrs_dict, read_multilevel_vars, read_single_level_vars, daily_date_iterator, align_coordinates, parse_arguments, get_pressure_levels_arg, LoadTemporalDataForDateDoFn
+
 from .pangeo import run, parse_args
+from .source_data import (
+    GCP_DIRECTORY,
+    SINGLE_LEVEL_VARIABLES,
+    MULTILEVEL_VARIABLES,
+    PRESSURE_LEVELS_GROUPS,
+    TIME_RESOLUTION_HOURS,
+    HOURS_PER_DAY,
+    get_var_attrs_dict,
+    read_multilevel_vars,
+    read_single_level_vars,
+    daily_date_iterator,
+    align_coordinates,
+    parse_arguments,
+    get_pressure_levels_arg,
+    LoadTemporalDataForDateDoFn
+    )
+
 from .update_ar import UpdateSlice as ARUpdateSlice
-from .update_co import GenerateOffset, UpdateSlice as COUpdateSlice
+from .update_co import GenerateOffset, UpdateSlice as COUpdateSlice, generate_input_paths

--- a/src/arco_era5/source_data.py
+++ b/src/arco_era5/source_data.py
@@ -4,7 +4,6 @@ __author__ = 'Matthew Willson, Alvaro Sanchez, Peter Battaglia, Stephan Hoyer, S
 
 import apache_beam as beam
 import argparse
-import datetime
 import fsspec
 import immutabledict
 import logging

--- a/src/arco_era5/source_data.py
+++ b/src/arco_era5/source_data.py
@@ -14,7 +14,7 @@ import numpy as np
 import pandas as pd
 import typing as t
 import xarray as xr
-import xarray_beam as xb
+import xarray_beam as xbeam
 
 TIME_RESOLUTION_HOURS = 1
 
@@ -567,7 +567,8 @@ def get_pressure_levels_arg(pressure_levels_group: str):
 
 class LoadTemporalDataForDateDoFn(beam.DoFn):
     """A Beam DoFn for loading temporal data for a specific date.
-    This class is responsible for loading temporal data for a given date, including both single-level and multi-level variables.
+
+    This class is responsible for loading temporal data for a given date, including both single-level and pressure-level variables.
     Args:
         data_path (str): The path to the data source.
         start_date (str): The start date in ISO format (YYYY-MM-DD).
@@ -633,7 +634,7 @@ class LoadTemporalDataForDateDoFn(beam.DoFn):
         dataset = align_coordinates(dataset)
         offsets = {"latitude": 0, "longitude": 0, "level": 0,
                    "time": offset_along_time_axis(self.start_date, year, month, day)}
-        key = xb.Key(offsets, vars=set(dataset.data_vars.keys()))
+        key = xbeam.Key(offsets, vars=set(dataset.data_vars.keys()))
         logging.info("Finished loading NetCDF files for %s-%s-%s", year, month, day)
         yield key, dataset
         dataset.close()

--- a/src/arco_era5/source_data.py
+++ b/src/arco_era5/source_data.py
@@ -567,13 +567,42 @@ def get_pressure_levels_arg(pressure_levels_group: str):
 
 
 class LoadTemporalDataForDateDoFn(beam.DoFn):
+    """A Beam DoFn for loading temporal data for a specific date.
+    This class is responsible for loading temporal data for a given date, including both single-level and multi-level variables.
+    Args:
+        data_path (str): The path to the data source.
+        start_date (str): The start date in ISO format (YYYY-MM-DD).
+        pressure_levels_group (str): The group label for the set of pressure levels.
+    Methods:
+        process(args): Loads temporal data for a specific date and yields it with an xarray_beam key.
+    Example:
+        >>> data_path = "gs://your-bucket/data/"
+        >>> start_date = "2023-09-01"
+        >>> pressure_levels_group = "weatherbench_13"
+        >>> loader = LoadTemporalDataForDateDoFn(data_path, start_date, pressure_levels_group)
+        >>> for result in loader.process((2023, 9, 11)):
+        ...     key, dataset = result
+        ...     print(f"Loaded data for key: {key}")
+        ...     print(dataset)
+    """
     def __init__(self, data_path, start_date, pressure_levels_group):
+        """Initialize the LoadTemporalDataForDateDoFn.
+        Args:
+            data_path (str): The path to the data source.
+            start_date (str): The start date in ISO format (YYYY-MM-DD).
+            pressure_levels_group (str): The group label for the set of pressure levels.
+        """
         self.data_path = data_path
         self.start_date = start_date
         self.pressure_levels_group = pressure_levels_group
 
     def process(self, args):
-        """Loads temporal data for a day, with an xarray_beam key for it."""
+        """Load temporal data for a day, with an xarray_beam key for it.
+        Args:
+            args (tuple): A tuple containing the year, month, and day.
+        Yields:
+            tuple: A tuple containing an xarray_beam key and the loaded dataset.
+        """
         year, month, day = args
         logging.info("Loading NetCDF files for %d-%d-%d", year, month, day)
 
@@ -595,7 +624,7 @@ class LoadTemporalDataForDateDoFn(beam.DoFn):
             # Make sure we print the date as part of the error for easier debugging
             # if something goes wrong. Note "from e" will also raise the details of the
             # original exception.
-            raise Exception(f"Error loading {year}-{month}-{day}") from e
+            raise RuntimeError(f"Error loading {year}-{month}-{day}") from e
 
         # It is crucial to actually "load" as otherwise we get a pickle error.
         single_level_vars = single_level_vars.load()

--- a/src/arco_era5/source_data.py
+++ b/src/arco_era5/source_data.py
@@ -1,3 +1,17 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 """Information and reading utils for the ERA 5 dataset."""
 
 __author__ = 'Matthew Willson, Alvaro Sanchez, Peter Battaglia, Stephan Hoyer, Stephan Rasp'

--- a/src/arco_era5/source_data.py
+++ b/src/arco_era5/source_data.py
@@ -2,17 +2,20 @@
 
 __author__ = 'Matthew Willson, Alvaro Sanchez, Peter Battaglia, Stephan Hoyer, Stephan Rasp'
 
+import apache_beam as beam
 import argparse
+import datetime
 import fsspec
 import immutabledict
+import logging
 
 import pathlib
-import xarray
 
 import numpy as np
 import pandas as pd
 import typing as t
 import xarray as xr
+import xarray_beam as xb
 
 TIME_RESOLUTION_HOURS = 1
 
@@ -334,6 +337,7 @@ _VARIABLE_TO_ERA5_FILE_NAME = {
     "geopotential_at_surface": "geopotential"
 }
 
+HOURS_PER_DAY = 24
 
 def _read_nc_dataset(gpath_file):
     """Read a .nc NetCDF dataset from a cloud storage path and disk.
@@ -352,7 +356,7 @@ def _read_nc_dataset(gpath_file):
     """
     path = str(gpath_file).replace('gs:/', 'gs://')
     with fsspec.open(path, mode="rb") as fid:
-        dataset = xarray.open_dataset(fid, engine="scipy", cache=False)
+        dataset = xr.open_dataset(fid, engine="scipy", cache=False)
     # All dataset have a single data array in them, so we just return the array.
     assert len(dataset) == 1
     dataarray = next(iter(dataset.values()))
@@ -412,7 +416,7 @@ def read_single_level_vars(year, month, day, variables=SINGLE_LEVEL_VARIABLES,
         relative_path = SINGLE_LEVEL_SUBDIR_TEMPLATE.format(
             year=year, month=month, day=day, variable=era5_variable)
         output[variable] = _read_nc_dataset(root_path / relative_path)
-    return xarray.Dataset(output)
+    return xr.Dataset(output)
 
 
 def read_multilevel_vars(year,
@@ -451,8 +455,8 @@ def read_multilevel_vars(year,
             single_level_data_array.coords["level"] = pressure_level
             pressure_data.append(
                 single_level_data_array.expand_dims(dim="level", axis=1))
-        output[variable] = xarray.concat(pressure_data, dim="level")
-    return xarray.Dataset(output)
+        output[variable] = xr.concat(pressure_data, dim="level")
+    return xr.Dataset(output)
 
 
 def get_var_attrs_dict(root_path=GCP_DIRECTORY):
@@ -558,6 +562,63 @@ def align_coordinates(dataset: xr.Dataset) -> xr.Dataset:
 
     return dataset
 
+def get_pressure_levels_arg(pressure_levels_group: str):
+    return PRESSURE_LEVELS_GROUPS[pressure_levels_group]
+
+
+class LoadTemporalDataForDateDoFn(beam.DoFn):
+    def __init__(self, data_path, start_date, pressure_levels_group):
+        self.data_path = data_path
+        self.start_date = start_date
+        self.pressure_levels_group = pressure_levels_group
+
+    def process(self, args):
+        """Loads temporal data for a day, with an xarray_beam key for it."""
+        year, month, day = args
+        logging.info("Loading NetCDF files for %d-%d-%d", year, month, day)
+
+        try:
+            single_level_vars = read_single_level_vars(
+                year,
+                month,
+                day,
+                variables=SINGLE_LEVEL_VARIABLES,
+                root_path=self.data_path)
+            multilevel_vars = read_multilevel_vars(
+                year,
+                month,
+                day,
+                variables=MULTILEVEL_VARIABLES,
+                pressure_levels=get_pressure_levels_arg(self.pressure_levels_group),
+                root_path=self.data_path)
+        except BaseException as e:
+            # Make sure we print the date as part of the error for easier debugging
+            # if something goes wrong. Note "from e" will also raise the details of the
+            # original exception.
+            raise Exception(f"Error loading {year}-{month}-{day}") from e
+
+        # It is crucial to actually "load" as otherwise we get a pickle error.
+        single_level_vars = single_level_vars.load()
+        multilevel_vars = multilevel_vars.load()
+
+        dataset = xr.merge([single_level_vars, multilevel_vars])
+        dataset = align_coordinates(dataset)
+        offsets = {"latitude": 0, "longitude": 0, "level": 0,
+                   "time": offset_along_time_axis(self.start_date, year, month, day)}
+        key = xb.Key(offsets, vars=set(dataset.data_vars.keys()))
+        logging.info("Finished loading NetCDF files for %s-%s-%s", year, month, day)
+        yield key, dataset
+        dataset.close()
+
+
+def offset_along_time_axis(start_date: str, year: int, month: int, day: int) -> int:
+    """Offset in indices along the time axis, relative to start of the dataset."""
+    # Note the length of years can vary due to leap years, so the chunk lengths
+    # will not always be the same, and we need to do a proper date calculation
+    # not just multiply by 365*24.
+    time_delta = pd.Timestamp(
+        year=year, month=month, day=day) - pd.Timestamp(start_date)
+    return time_delta.days * HOURS_PER_DAY // TIME_RESOLUTION_HOURS
 
 def parse_arguments(desc: str) -> t.Tuple[argparse.Namespace, t.List[str]]:
     """Parse command-line arguments for the data processing pipeline.
@@ -580,8 +641,6 @@ def parse_arguments(desc: str) -> t.Tuple[argparse.Namespace, t.List[str]]:
                         help='Start date, iso format string.')
     parser.add_argument('-e', "--end_date", default='2020-01-02',
                         help='End date, iso format string.')
-    parser.add_argument("--temp_location", type=str, required=True,
-                        help="A temp location where this data is stored temporarily.")
     parser.add_argument('--find-missing', action='store_true', default=False,
                         help='Print all paths to missing input data.')  # implementation pending
     parser.add_argument("--pressure_levels_group", type=str, default="weatherbench_13",
@@ -589,5 +648,11 @@ def parse_arguments(desc: str) -> t.Tuple[argparse.Namespace, t.List[str]]:
     parser.add_argument("--time_chunk_size", type=int, required=True,
                         help="Number of 1-hourly timesteps to include in a \
                         single chunk. Must evenly divide 24.")
+    parser.add_argument("--init_date", type=str, default='1900-01-01',
+                        help="Date to initialize the zarr store.")
+    parser.add_argument("--from_init_date", action='store_true', default=False,
+                        help="To initialize the store from some previous date (--init_date). i.e. 1900-01-01")
+    parser.add_argument("--only_initialize_store", action='store_true', default=False,
+                        help="Initialize zarr store without data.")
 
     return parser.parse_known_args()

--- a/src/arco_era5/update_ar.py
+++ b/src/arco_era5/update_ar.py
@@ -1,3 +1,17 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import apache_beam as beam
 import datetime
 import logging

--- a/src/arco_era5/update_ar.py
+++ b/src/arco_era5/update_ar.py
@@ -1,0 +1,36 @@
+import apache_beam as beam
+import datetime
+import logging
+import xarray as xr
+import zarr
+
+from arco_era5 import HOURS_PER_DAY
+from dataclasses import dataclass
+from typing import Tuple
+
+logger = logging.getLogger(__name__)
+
+@dataclass
+class UpdateSlice(beam.PTransform):
+
+    target: str
+    init_date: str
+
+    def apply(self, offset_ds: Tuple[int, xr.Dataset, str]):
+        """Generate region slice and update zarr array directly"""
+        key, ds = offset_ds
+        offset = key.offsets['time']
+        date = datetime.datetime.strptime(self.init_date, '%Y-%m-%d') + datetime.timedelta(days=offset / HOURS_PER_DAY)
+        date_str = date.strftime('%Y-%m-%d')
+        zf = zarr.open(self.target)
+        region = slice(offset, offset + HOURS_PER_DAY)
+        for vname in ds.data_vars:
+            logger.info(f"Started {vname} for {date_str}")
+            zv = zf[vname]
+            zv[region] = ds[vname].values
+            logger.info(f"Done {vname} for {date_str}")
+        del zv
+        del ds
+
+    def expand(self, pcoll: beam.PCollection) -> beam.PCollection:
+        return pcoll | beam.Map(self.apply)

--- a/src/arco_era5/update_ar.py
+++ b/src/arco_era5/update_ar.py
@@ -30,12 +30,18 @@ logger = logging.getLogger(__name__)
 
 @dataclass
 class UpdateSlice(beam.PTransform):
+    """A Beam PTransform to write zarr arrays from the raw grib files and time offset."""
 
     target: str
     init_date: str
 
     def apply(self, key: xb.Key, ds: xr.Dataset) -> None:
-        """Generate region slice and update zarr array directly"""
+        """A method to write zarr arrays from the raw grib files and time offset.
+
+        Args:
+            key (xb.Key): offset dict for dimensions.
+            ds (xr.Dataset): Merged dataset for a single day.
+        """
         offset = key.offsets['time']
         date = (datetime.datetime.strptime(self.init_date, '%Y-%m-%d') +
                 datetime.timedelta(days=offset / HOURS_PER_DAY))

--- a/src/arco_era5/update_co.py
+++ b/src/arco_era5/update_co.py
@@ -1,3 +1,17 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import apache_beam as beam
 import calendar
 import datetime

--- a/src/arco_era5/update_co.py
+++ b/src/arco_era5/update_co.py
@@ -1,0 +1,125 @@
+import apache_beam as beam
+import logging
+import subprocess
+import tempfile
+import os
+import datetime
+import xarray as xr
+import zarr as zr
+from dataclasses import dataclass
+from contextlib import contextmanager
+import calendar
+
+logger = logging.getLogger(__name__)
+
+variable_dict = {
+    'dve': ['d', 'vo'], # model-level-wind
+    'tw': ['t', 'w'],
+    'o3q': ['q', 'o3', 'clwc', 'ciwc', 'cc'], # model-level-moisture
+    'qrqs': ['crwc', 'cswc'],
+    'lnsp': ['lnsp'], # single-level-surface
+    'zs': ['z'],
+    'cape': ['p79.162', 'p80.162'], # single-level-reanalysis
+    'cisst': ['siconc', 'sst', 'skt'],
+    'sfc': ['z', 'sp', 'tcwv', 'msl', 'tcc', 'u10', 'v10', 't2m', 'd2m', 'lcc', 'mcc', 'hcc', 'u100', 'v100'],
+    'tcol': ['tclw', 'tciw', 'tcw', 'tcwv', 'tcrw', 'tcsw'],
+    'soil_depthBelowLandLayer_istl1': ['istl1'],
+    'soil_depthBelowLandLayer_istl2': ['istl2'],
+    'soil_depthBelowLandLayer_istl3': ['istl3'],
+    'soil_depthBelowLandLayer_istl4': ['istl4'],
+    'soil_depthBelowLandLayer_stl1': ['stl1'],
+    'soil_depthBelowLandLayer_stl2': ['stl2'],
+    'soil_depthBelowLandLayer_stl3': ['stl3'],
+    'soil_depthBelowLandLayer_stl4': ['stl4'],
+    'soil_depthBelowLandLayer_swvl1': ['swvl1'],
+    'soil_depthBelowLandLayer_swvl2': ['swvl2'],
+    'soil_depthBelowLandLayer_swvl3': ['swvl3'],
+    'soil_depthBelowLandLayer_swvl4': ['swvl4'],
+    'soil_surface_tsn': ['tsn'],
+    'rad': ['ssrd', 'strd', 'str', 'ttr', 'gwd'], # single-level-forecast
+    'pcp_surface_cp': ['cp'],
+    'pcp_surface_crr': ['crr'],
+    'pcp_surface_csf': ['csf'],
+    'pcp_surface_csfr': ['csfr'],
+    'pcp_surface_es': ['es'],
+    'pcp_surface_lsf': ['lsf'],
+    'pcp_surface_lsp': ['lsp'],
+    'pcp_surface_lspf': ['lspf'],
+    'pcp_surface_lsrr': ['lsrr'],
+    'pcp_surface_lssfr': ['lssfr'],
+    'pcp_surface_ptype': ['ptype'],
+    'pcp_surface_rsn': ['rsn'],
+    'pcp_surface_sd': ['sd'],
+    'pcp_surface_sf': ['sf'],
+    'pcp_surface_smlt': ['smlt'],
+    'pcp_surface_tp': ['tp']
+}
+
+def convert_to_date(date_str: str, format: str = '%Y-%m-%d'):
+    return datetime.datetime.strptime(date_str, format)
+
+def copy(src: str, dst: str):
+    cmd = 'gcloud alpha storage cp'
+    try:
+        subprocess.run(cmd.split() + [src, dst], check=True, capture_output=True, text=True, input="n/n")
+        return
+    except subprocess.CalledProcessError as e:
+        msg = f"Failed to copy file {src!r} to {dst!r} Error {e}"
+        logger.error(msg)
+
+@contextmanager
+def opener(fname: str):
+    _, suffix = os.path.splitext(fname)
+    with tempfile.NamedTemporaryFile(suffix=suffix) as ntf:
+        tmp_name = ntf.name
+        logger.info(f"Copying '{fname}' to local file '{tmp_name}'")
+        copy(fname, tmp_name)
+        yield tmp_name
+
+@dataclass
+class GenerateOffset(beam.PTransform):
+
+    init_date: str = '1900-01-01'
+    timestamps_per_file: int = 24
+    is_single_level: bool = False
+
+    def apply(self, url: str):
+        # generate start offset
+        file_name = url.rsplit('/', 1)[1].rsplit('.', 1)[0]
+        int_date, chunk = file_name.split('_hres_')
+        if "_" in chunk:
+            chunk = chunk.replace(".grb2_", "_")
+        if self.is_single_level:
+            int_date += "01"
+        start_date = convert_to_date(int_date, '%Y%m%d')
+        days_diff = start_date - convert_to_date(self.init_date)
+        start = days_diff.days * self.timestamps_per_file
+        end = start + self.timestamps_per_file * (calendar.monthrange(start_date.year, start_date.month)[1] if self.is_single_level else 1)
+        return url, slice(start, end), variable_dict[chunk]
+
+    def expand(self, pcoll: beam.PCollection) -> beam.PCollection:
+        return pcoll | beam.Map(self.apply)
+
+
+@dataclass
+class UpdateSlice(beam.PTransform):
+
+    target: str
+
+    def apply(self, file_slice):
+        url, region, vars = file_slice
+        zf = zr.open(self.target)
+        with opener(url) as file:
+            logger.info(f"Opened {url}")
+            ds = xr.open_dataset(file, engine='cfgrib')
+            for vname in vars:
+                logger.info(f"Started {vname} from {url}")
+                zv = zf[vname]
+                zv[region] = ds[vname].values
+                logger.info(f"Done {vname} from {url}")
+            logger.info(f"Finished for {url}")
+            del zv
+            del ds
+
+    def expand(self, pcoll: beam.PCollection) -> beam.PCollection:
+        return pcoll | beam.Map(self.apply)

--- a/src/arco_era5/update_co.py
+++ b/src/arco_era5/update_co.py
@@ -12,32 +12,44 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import apache_beam as beam
 import calendar
 import datetime
 import logging
 import os
 import subprocess
 import tempfile
-import xarray as xr
 import zarr
+
+import apache_beam as beam
+import pandas as pd
+import typing as t
+import xarray as xr
 
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import List, Tuple
+from itertools import product
 
 logger = logging.getLogger(__name__)
 
-VARIABLE_DICT = {
-    'dve': ['d', 'vo'], # model-level-wind
+SINGLE_LEVEL_SUBDIR_TEMPLATE = (
+    "ERA5GRIB/HRES/Month/{year}/{year}{month:02d}_hres_{chunk}.grb2"
+)
+
+MODELLEVEL_SUBDIR_TEMPLATE = (
+    "ERA5GRIB/HRES/Daily/{year}/{year}{month:02d}{day:02d}_hres_{chunk}.grb2"
+)
+
+VARIABLE_DICT: t.Dict[str, t.List[str]] = {
+    'dve': ['d', 'vo'],  # model-level-wind
     'tw': ['t', 'w'],
-    'o3q': ['q', 'o3', 'clwc', 'ciwc', 'cc'], # model-level-moisture
+    'o3q': ['q', 'o3', 'clwc', 'ciwc', 'cc'],  # model-level-moisture
     'qrqs': ['crwc', 'cswc'],
-    'lnsp': ['lnsp'], # single-level-surface
+    'lnsp': ['lnsp'],  # single-level-surface
     'zs': ['z'],
-    'cape': ['cape', 'p79.162', 'p80.162'], # single-level-reanalysis
+    'cape': ['cape', 'p79.162', 'p80.162'],  # single-level-reanalysis
     'cisst': ['siconc', 'sst', 'skt'],
-    'sfc': ['z', 'sp', 'tcwv', 'msl', 'tcc', 'u10', 'v10', 't2m', 'd2m', 'lcc', 'mcc', 'hcc', 'u100', 'v100'],
+    'sfc': ['z', 'sp', 'tcwv', 'msl', 'tcc', 'u10', 'v10', 't2m',
+            'd2m', 'lcc', 'mcc', 'hcc', 'u100', 'v100'],
     'tcol': ['tclw', 'tciw', 'tcw', 'tcwv', 'tcrw', 'tcsw'],
     'soil_depthBelowLandLayer_istl1': ['istl1'],
     'soil_depthBelowLandLayer_istl2': ['istl2'],
@@ -52,7 +64,7 @@ VARIABLE_DICT = {
     'soil_depthBelowLandLayer_swvl3': ['swvl3'],
     'soil_depthBelowLandLayer_swvl4': ['swvl4'],
     'soil_surface_tsn': ['tsn'],
-    'rad': ['ssrd', 'strd', 'str', 'ttr', 'gwd'], # single-level-forecast
+    'rad': ['ssrd', 'strd', 'str', 'ttr', 'gwd'],  # single-level-forecast
     'pcp_surface_cp': ['cp'],
     'pcp_surface_crr': ['crr'],
     'pcp_surface_csf': ['csf'],
@@ -71,26 +83,48 @@ VARIABLE_DICT = {
     'pcp_surface_tp': ['tp']
 }
 
+
 def convert_to_date(date_str: str, format: str = '%Y-%m-%d') -> datetime.datetime:
     return datetime.datetime.strptime(date_str, format)
 
-def copy(src: str, dst: str):
+
+def copy(src: str, dst: str) -> None:
     cmd = 'gcloud alpha storage cp'
     try:
-        subprocess.run(cmd.split() + [src, dst], check=True, capture_output=True, text=True, input="n/n")
+        subprocess.run(cmd.split() + [src, dst], check=True, capture_output=True,
+                       text=True, input="n/n")
         return
     except subprocess.CalledProcessError as e:
         msg = f"Failed to copy file {src!r} to {dst!r} Error {e}"
         logger.error(msg)
 
+
 @contextmanager
-def opener(fname: str):
+def opener(fname: str) -> t.Any:
     _, suffix = os.path.splitext(fname)
     with tempfile.NamedTemporaryFile(suffix=suffix) as ntf:
         tmp_name = ntf.name
         logger.info(f"Copying '{fname}' to local file '{tmp_name}'")
         copy(fname, tmp_name)
         yield tmp_name
+
+
+def generate_input_paths(start: str, end: str, root_path: str, chunks: t.List[str], is_single_level: bool = False):
+    input_paths = []
+    for time, chunk in product(pd.date_range(start, end, freq="MS" if is_single_level else "D"), chunks):
+        if is_single_level:
+            url = f"{root_path}/{SINGLE_LEVEL_SUBDIR_TEMPLATE.format(year=time.year, month=time.month, day=time.day, chunk=chunk)}"
+        else:
+            url = f"{root_path}/{MODELLEVEL_SUBDIR_TEMPLATE.format(year=time.year, month=time.month, day=time.day, chunk=chunk)}"
+        
+        if '_' in chunk:
+            chunk_, level, var = chunk.split('_')
+            url = url.replace(chunk, chunk_)
+            url = f"{url}_{level}_{var}.grib"
+        input_paths.append(url)
+
+    return input_paths
+
 
 @dataclass
 class GenerateOffset(beam.PTransform):
@@ -99,7 +133,7 @@ class GenerateOffset(beam.PTransform):
     timestamps_per_file: int = 24
     is_single_level: bool = False
 
-    def apply(self, url: str):
+    def apply(self, url: str) -> t.Tuple[str, slice, t.List[str]]:
         # generate start offset
         file_name = url.rsplit('/', 1)[1].rsplit('.', 1)[0]
         int_date, chunk = file_name.split('_hres_')
@@ -110,7 +144,9 @@ class GenerateOffset(beam.PTransform):
         start_date = convert_to_date(int_date, '%Y%m%d')
         days_diff = start_date - convert_to_date(self.init_date)
         start = days_diff.days * self.timestamps_per_file
-        end = start + self.timestamps_per_file * (calendar.monthrange(start_date.year, start_date.month)[1] if self.is_single_level else 1)
+        end = start + self.timestamps_per_file * (
+            calendar.monthrange(start_date.year,
+                                start_date.month)[1] if self.is_single_level else 1)
         return url, slice(start, end), VARIABLE_DICT[chunk]
 
     def expand(self, pcoll: beam.PCollection) -> beam.PCollection:
@@ -122,7 +158,7 @@ class UpdateSlice(beam.PTransform):
 
     target: str
 
-    def apply(self, file_slice: Tuple[str, slice, List[str]]):
+    def apply(self, file_slice: t.Tuple[str, slice, t.List[str]]) -> None:
         url, region, vars = file_slice
         zf = zarr.open(self.target)
         with opener(url) as file:

--- a/src/arco_era5/update_co.py
+++ b/src/arco_era5/update_co.py
@@ -19,7 +19,7 @@ variable_dict = {
     'qrqs': ['crwc', 'cswc'],
     'lnsp': ['lnsp'], # single-level-surface
     'zs': ['z'],
-    'cape': ['p79.162', 'p80.162'], # single-level-reanalysis
+    'cape': ['cape', 'p79.162', 'p80.162'], # single-level-reanalysis
     'cisst': ['siconc', 'sst', 'skt'],
     'sfc': ['z', 'sp', 'tcwv', 'msl', 'tcc', 'u10', 'v10', 't2m', 'd2m', 'lcc', 'mcc', 'hcc', 'u100', 'v100'],
     'tcol': ['tclw', 'tciw', 'tcw', 'tcwv', 'tcrw', 'tcsw'],

--- a/src/netcdf_to_zarr.py
+++ b/src/netcdf_to_zarr.py
@@ -1,3 +1,16 @@
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 # pylint: disable=line-too-long
 r"""Create a single Zarr dataset from ERA5 NetCDF files.
 

--- a/src/netcdf_to_zarr.py
+++ b/src/netcdf_to_zarr.py
@@ -16,12 +16,12 @@ Example usage:
 
     Generate zarr store from start_date with data
 
-    python src/netcdf_to_zarr.py \
-      --output_path="gs://gcp-public-data-arco-era5/ar/$USER-1959-2022-full_37-1h-0p25deg-chunk-1.zarr-v2" \
+  python src/netcdf_to_zarr.py \
+      --output_path="gs://gcp-public-data-arco-era5/ar/full_37-1h-0p25deg-chunk-1.zarr-v3" \
       --pressure_levels_group="full_37" \
       --time_chunk_size=1 \
-      --start_date '1959-01-01' \
-      --end_date '2021-12-31' \
+      --start_date '1940-01-01' \
+      --end_date '2023-01-01' \
       --runner DataflowRunner \
       --project $PROJECT \
       --region $REGION \
@@ -32,7 +32,7 @@ Example usage:
       --no_use_public_ips  \
       --network=$NETWORK \
       --subnetwork=regions/$REGION/subnetworks/$SUBNET \
-      --job_name $USER-ar-zarr-full \
+      --job_name ar-zarr-full \
       --number_of_worker_harness_threads 20
 
     Generate zarr store from init_date and fill data from start_date. Default init_date will be 1900-01-01
@@ -96,8 +96,6 @@ Example usage:
       --subnetwork=regions/$REGION/subnetworks/$SUBNET \
       --job_name $USER-ar-zarr-full \
       --number_of_worker_harness_threads 20
-    ```
-
 """
 
 # TODO(alvarosg): Make this pipeline resumable in case of error in the middle
@@ -352,8 +350,8 @@ def main():
 
     pipeline_args.extend(['--save_main_session', 'True'])
 
-    if fs.exists(known_args.output_path):
-        raise ValueError(f"{known_args.output_path} already exists")
+    # if fs.exists(known_args.output_path):
+    #     raise ValueError(f"{known_args.output_path} already exists")
 
     num_steps_per_day = HOURS_PER_DAY // TIME_RESOLUTION_HOURS
     if num_steps_per_day % known_args.time_chunk_size != 0:

--- a/src/netcdf_to_zarr.py
+++ b/src/netcdf_to_zarr.py
@@ -14,7 +14,9 @@ subsequent years by:
 
 Example usage:
 
-  $ python src/netcdf_to_zarr.py \
+    Generate zarr store from start_date with data
+
+    python src/netcdf_to_zarr.py \
       --output_path="gs://gcp-public-data-arco-era5/ar/$USER-1959-2022-full_37-1h-0p25deg-chunk-1.zarr-v2" \
       --pressure_levels_group="full_37" \
       --time_chunk_size=1 \
@@ -32,6 +34,70 @@ Example usage:
       --subnetwork=regions/$REGION/subnetworks/$SUBNET \
       --job_name $USER-ar-zarr-full \
       --number_of_worker_harness_threads 20
+
+    Generate zarr store from init_date and fill data from start_date. Default init_date will be 1900-01-01
+
+    ```
+    python src/netcdf_to_zarr.py \
+      --output_path="gs://gcp-public-data-arco-era5/ar/$USER-1959-2022-full_37-1h-0p25deg-chunk-1.zarr-v2" \
+      --pressure_levels_group="full_37" \
+      --time_chunk_size=1 \
+      --start_date '1959-01-01' \
+      --end_date '2021-12-31' \
+      --init_date '1900-01-01' \
+      --from_init_date
+      --runner DataflowRunner \
+      --project $PROJECT \
+      --region $REGION \
+      --temp_location "gs://$BUCKET/tmp/" \
+      --setup_file ./setup.py \
+      --disk_size_gb 500 \
+      --machine_type m1-ultramem-40 \
+      --no_use_public_ips  \
+      --network=$NETWORK \
+      --subnetwork=regions/$REGION/subnetworks/$SUBNET \
+      --job_name $USER-ar-zarr-full \
+      --number_of_worker_harness_threads 20
+    ```
+
+    Generate zarr store from init_date without data. Default init_date will be 1900-01-01. Static variables will be loaded.
+
+    ```
+    python src/netcdf_to_zarr.py \
+      --output_path="gs://gcp-public-data-arco-era5/ar/$USER-1959-2022-full_37-1h-0p25deg-chunk-1.zarr-v2" \
+      --pressure_levels_group="full_37" \
+      --time_chunk_size=1 \
+      --start_date '1959-01-01' \
+      --end_date '2021-12-31' \
+      --init_date '1800-01-01' \
+      --from_init_date \
+      --only_initialize_store
+    ```
+
+    Seed data in the existing store.
+
+    ```
+    python src/update-data.py \
+      --output_path="gs://gcp-public-data-arco-era5/ar/$USER-1959-2022-full_37-1h-0p25deg-chunk-1.zarr-v2" \
+      --pressure_levels_group="full_37" \
+      --time_chunk_size=1 \
+      --start_date '1959-01-01' \
+      --end_date '2021-12-31' \
+      --init_date '1900-01-01' \
+      --runner DataflowRunner \
+      --project $PROJECT \
+      --region $REGION \
+      --temp_location "gs://$BUCKET/tmp/" \
+      --setup_file ./setup.py \
+      --disk_size_gb 500 \
+      --machine_type m1-ultramem-40 \
+      --no_use_public_ips  \
+      --network=$NETWORK \
+      --subnetwork=regions/$REGION/subnetworks/$SUBNET \
+      --job_name $USER-ar-zarr-full \
+      --number_of_worker_harness_threads 20
+    ```
+
 """
 
 # TODO(alvarosg): Make this pipeline resumable in case of error in the middle
@@ -44,6 +110,7 @@ import fsspec
 import logging
 
 import apache_beam as beam
+import datetime
 import numpy as np
 import pandas as pd
 import typing as t
@@ -52,37 +119,21 @@ import xarray_beam as xb
 
 from arco_era5 import (
     GCP_DIRECTORY,
+    HOURS_PER_DAY,
     SINGLE_LEVEL_VARIABLES,
     MULTILEVEL_VARIABLES,
-    PRESSURE_LEVELS_GROUPS,
     TIME_RESOLUTION_HOURS,
+    get_pressure_levels_arg,
     get_var_attrs_dict,
     read_multilevel_vars,
-    read_single_level_vars,
     daily_date_iterator,
     align_coordinates,
-    parse_arguments
+    parse_arguments,
+    LoadTemporalDataForDateDoFn
 )
 
 INPUT_PATH = GCP_DIRECTORY
-_HOURS_PER_DAY = 24
 # TODO(alvarosg): Add pressure level chunk size.
-
-
-def _get_pressure_levels_arg(pressure_levels_group: str):
-    """Get pressure levels based on a pressure levels group.
-
-    Args:
-        pressure_levels_group (str): The group label for the set of pressure levels.
-
-    Returns:
-        list: A list of pressure levels.
-
-    Example:
-        >>> pressure_levels = _get_pressure_levels_arg("weatherbench_13")
-    """
-    return PRESSURE_LEVELS_GROUPS[pressure_levels_group]
-
 
 def make_template(data_path: str, start_date: str, end_date: str, time_chunk_size: int,
                   pressure_levels_group: str) -> t.Tuple[xa.Dataset, t.Dict[str, int]]:
@@ -115,24 +166,23 @@ def make_template(data_path: str, start_date: str, end_date: str, time_chunk_siz
     # Get some sample multi-level data to get coordinates, only for one var,
     # so it downloads quickly.
     logging.info("Downloading one variable of sample data for template.")
-    first_year, first_month, first_day = next(iter(
-        daily_date_iterator(start_date, end_date)))
+    date = datetime.datetime.strptime(end_date, '%Y-%m-%d') - datetime.timedelta(days=1)
     sample_multilevel_vars = align_coordinates(
         read_multilevel_vars(
             # Date is irrelevant.
-            first_year,
-            first_month,
-            first_day,
+            date.year,
+            date.month,
+            date.day,
             root_path=data_path,
             variables=MULTILEVEL_VARIABLES[:1],
-            pressure_levels=_get_pressure_levels_arg(pressure_levels_group)))
+            pressure_levels=get_pressure_levels_arg(pressure_levels_group)))
     logging.info("Finished downloading.")
 
     lat_size = sample_multilevel_vars.sizes["latitude"]
     lon_size = sample_multilevel_vars.sizes["longitude"]
     level_size = sample_multilevel_vars.sizes["level"]
     assert level_size == len(
-        _get_pressure_levels_arg(pressure_levels_group)
+        get_pressure_levels_arg(pressure_levels_group)
     ), "Mismatched level sizes"
 
     # Take the coordinates from the richer, multi-level dataset.
@@ -141,6 +191,7 @@ def make_template(data_path: str, start_date: str, end_date: str, time_chunk_siz
         pd.Timestamp(start_date),
         pd.Timestamp(end_date),
         freq=pd.DateOffset(hours=TIME_RESOLUTION_HOURS),
+        inclusive="left"
         ).values
     time_size = len(coords["time"])
 
@@ -165,88 +216,6 @@ def make_template(data_path: str, start_date: str, end_date: str, time_chunk_siz
 
     chunk_sizes = {"time": time_chunk_size}
     return xa.Dataset(template_dataset, coords=coords), chunk_sizes
-
-
-class LoadTemporalDataForDateDoFn(beam.DoFn):
-    """A Beam DoFn for loading temporal data for a specific date.
-
-    This class is responsible for loading temporal data for a given date, including both single-level and multi-level variables.
-
-    Args:
-        data_path (str): The path to the data source.
-        start_date (str): The start date in ISO format (YYYY-MM-DD).
-        pressure_levels_group (str): The group label for the set of pressure levels.
-
-    Methods:
-        process(args): Loads temporal data for a specific date and yields it with an xarray_beam key.
-
-    Example:
-        >>> data_path = "gs://your-bucket/data/"
-        >>> start_date = "2023-09-01"
-        >>> pressure_levels_group = "weatherbench_13"
-        >>> loader = LoadTemporalDataForDateDoFn(data_path, start_date, pressure_levels_group)
-        >>> for result in loader.process((2023, 9, 11)):
-        ...     key, dataset = result
-        ...     print(f"Loaded data for key: {key}")
-        ...     print(dataset)
-    """
-    def __init__(self, data_path, start_date, pressure_levels_group):
-        """Initialize the LoadTemporalDataForDateDoFn.
-
-        Args:
-            data_path (str): The path to the data source.
-            start_date (str): The start date in ISO format (YYYY-MM-DD).
-            pressure_levels_group (str): The group label for the set of pressure levels.
-        """
-        self.data_path = data_path
-        self.start_date = start_date
-        self.pressure_levels_group = pressure_levels_group
-
-    def process(self, args):
-        """Load temporal data for a day, with an xarray_beam key for it.
-
-        Args:
-            args (tuple): A tuple containing the year, month, and day.
-
-        Yields:
-            tuple: A tuple containing an xarray_beam key and the loaded dataset.
-        """
-        year, month, day = args
-        logging.info("Loading NetCDF files for %d-%d-%d", year, month, day)
-
-        try:
-            single_level_vars = read_single_level_vars(
-                year,
-                month,
-                day,
-                variables=SINGLE_LEVEL_VARIABLES,
-                root_path=self.data_path)
-            multilevel_vars = read_multilevel_vars(
-                year,
-                month,
-                day,
-                variables=MULTILEVEL_VARIABLES,
-                pressure_levels=_get_pressure_levels_arg(self.pressure_levels_group),
-                root_path=self.data_path)
-        except BaseException as e:
-            # Make sure we print the date as part of the error for easier debugging
-            # if something goes wrong. Note "from e" will also raise the details of the
-            # original exception.
-            raise Exception(f"Error loading {year}-{month}-{day}") from e
-
-        # It is crucial to actually "load" as otherwise we get a pickle error.
-        single_level_vars = single_level_vars.load()
-        multilevel_vars = multilevel_vars.load()
-
-        dataset = xa.merge([single_level_vars, multilevel_vars])
-        dataset = align_coordinates(dataset)
-        offsets = {"latitude": 0, "longitude": 0, "level": 0,
-                   "time": offset_along_time_axis(self.start_date, year, month, day)}
-        key = xb.Key(offsets, vars=set(dataset.data_vars.keys()))
-        logging.info("Finished loading NetCDF files for %s-%s-%s", year, month, day)
-        yield key, dataset
-        dataset.close()
-
 
 def offset_along_time_axis(start_date: str, year: int, month: int, day: int) -> int:
     """Calculate the offset in indices along the time axis relative to the start date of the dataset.
@@ -276,7 +245,7 @@ def offset_along_time_axis(start_date: str, year: int, month: int, day: int) -> 
     # not just multiply by 365*24.
     time_delta = pd.Timestamp(
         year=year, month=month, day=day) - pd.Timestamp(start_date)
-    return time_delta.days * _HOURS_PER_DAY // TIME_RESOLUTION_HOURS
+    return time_delta.days * HOURS_PER_DAY // TIME_RESOLUTION_HOURS
 
 
 def define_pipeline(
@@ -286,7 +255,10 @@ def define_pipeline(
     time_chunk_size: int,
     start_date: str,
     end_date: str,
-    pressure_levels_group: str
+    pressure_levels_group: str,
+    init_date: str,
+    from_init_date: bool,
+    only_initialize_store: bool
 ) -> t.Tuple[beam.Pipeline, beam.Pipeline]:
     """Define a Beam pipeline to convert ERA5 NetCDF files to Zarr format.
 
@@ -319,7 +291,7 @@ def define_pipeline(
     """
 
     template, chunk_sizes = make_template(
-        input_path, start_date, end_date, time_chunk_size, pressure_levels_group)
+        input_path, init_date if from_init_date else start_date, end_date, time_chunk_size, pressure_levels_group)
 
     # We will create a single `chunks_to_zarr` object, but connect it at the end
     # of the two pipelines separately. This causes the full transformation to be
@@ -339,22 +311,24 @@ def define_pipeline(
         template=xb.make_template(template),
         zarr_chunks=chunk_sizes)
 
-    load_temporal_data_for_date_do_fn = LoadTemporalDataForDateDoFn(
-        data_path=input_path,
-        start_date=start_date,
-        pressure_levels_group=pressure_levels_group
-    )
-    logging.info("Setting up temporal variables.")
-    temporal_variables_chunks = (
-            root
-            | "DayIterator" >> beam.Create(daily_date_iterator(start_date, end_date))
-            | "TemporalDataForDay" >> beam.ParDo(load_temporal_data_for_date_do_fn)
-            | xb.SplitChunks(chunk_sizes)
-            # We can skip the consolidation if we are using a `time_chunk_size` that
-            # evenly divides a day worth of data.
-            # | xb.ConsolidateChunks(chunk_sizes)
-            | "ChunksToZarrTemporal" >> chunks_to_zarr
-    )
+    temporal_variables_chunks = None
+    if not only_initialize_store:
+        load_temporal_data_for_date_do_fn = LoadTemporalDataForDateDoFn(
+            data_path=input_path,
+            start_date=init_date if from_init_date else start_date,
+            pressure_levels_group=pressure_levels_group
+        )
+        logging.info("Setting up temporal variables.")
+        temporal_variables_chunks = (
+                root
+                | "DayIterator" >> beam.Create(daily_date_iterator(start_date, end_date))
+                | "TemporalDataForDay" >> beam.ParDo(load_temporal_data_for_date_do_fn)
+                | xb.SplitChunks(chunk_sizes)
+                # We can skip the consolidation if we are using a `time_chunk_size` that
+                # evenly divides a day worth of data.
+                # | xb.ConsolidateChunks(chunk_sizes)
+                | "ChunksToZarrTemporal" >> chunks_to_zarr
+        )
 
     logging.info("Finished defining pipeline.")
     return temporal_variables_chunks
@@ -373,12 +347,15 @@ def main():
     known_args, pipeline_args = parse_arguments(
         "Create a Zarr dataset from NetCDF files."
     )
+    if known_args.init_date != "1900-01-01" and (not known_args.from_init_date):
+        raise RuntimeError("--init_date can only be used along with --from_init_date flag.")
+
     pipeline_args.extend(['--save_main_session', 'True'])
 
     if fs.exists(known_args.output_path):
         raise ValueError(f"{known_args.output_path} already exists")
 
-    num_steps_per_day = _HOURS_PER_DAY // TIME_RESOLUTION_HOURS
+    num_steps_per_day = HOURS_PER_DAY // TIME_RESOLUTION_HOURS
     if num_steps_per_day % known_args.time_chunk_size != 0:
         raise ValueError(
             f"time_chunk_size {known_args.time_chunk_size} must evenly divide {num_steps_per_day}"
@@ -392,7 +369,10 @@ def main():
             start_date=known_args.start_date,
             end_date=known_args.end_date,
             time_chunk_size=known_args.time_chunk_size,
-            pressure_levels_group=known_args.pressure_levels_group
+            pressure_levels_group=known_args.pressure_levels_group,
+            init_date=known_args.init_date,
+            from_init_date=known_args.from_init_date,
+            only_initialize_store=known_args.only_initialize_store
         )
 
 

--- a/src/netcdf_to_zarr.py
+++ b/src/netcdf_to_zarr.py
@@ -350,8 +350,8 @@ def main():
 
     pipeline_args.extend(['--save_main_session', 'True'])
 
-    # if fs.exists(known_args.output_path):
-    #     raise ValueError(f"{known_args.output_path} already exists")
+    if fs.exists(known_args.output_path):
+        raise ValueError(f"{known_args.output_path} already exists")
 
     num_steps_per_day = HOURS_PER_DAY // TIME_RESOLUTION_HOURS
     if num_steps_per_day % known_args.time_chunk_size != 0:

--- a/src/update-ar-data.py
+++ b/src/update-ar-data.py
@@ -1,24 +1,26 @@
 import apache_beam as beam
-from arco_era5 import (
-    daily_date_iterator, 
-    LoadTemporalDataForDateDoFn, 
-    GCP_DIRECTORY, 
-    ARUpdateSlice,
-)
 import argparse
 import logging
-from typing import Tuple, List
+
+import typing as t
+
+from arco_era5 import (
+    daily_date_iterator,
+    LoadTemporalDataForDateDoFn,
+    GCP_DIRECTORY,
+    ARUpdateSlice,
+)
 
 logging.getLogger().setLevel(logging.INFO)
 
-def parse_arguments(desc: str) -> Tuple[argparse.Namespace, List[str]]:
+def parse_arguments(desc: str) -> t.Tuple[argparse.Namespace, t.List[str]]:
     parser = argparse.ArgumentParser(description=desc)
 
     parser.add_argument("--output_path", type=str, required=True,
                         help="Path to the destination Zarr archive.")
-    parser.add_argument('-s', "--start_date", default='2020-01-01',
+    parser.add_argument('-s', "--start_date", required=True,
                         help='Start date, iso format string.')
-    parser.add_argument('-e', "--end_date", default='2020-01-02',
+    parser.add_argument('-e', "--end_date", required=True,
                         help='End date, iso format string.')
     parser.add_argument("--pressure_levels_group", type=str, default="weatherbench_13",
                         help="Group label for the set of pressure levels to use.")

--- a/src/update-ar-data.py
+++ b/src/update-ar-data.py
@@ -1,0 +1,33 @@
+import apache_beam as beam
+from arco_era5 import daily_date_iterator, LoadTemporalDataForDateDoFn, GCP_DIRECTORY, ARUpdateSlice
+import logging
+import argparse
+from typing import Tuple, List
+
+logging.getLogger().setLevel(logging.INFO)
+
+def parse_arguments(desc: str) -> Tuple[argparse.Namespace, List[str]]:
+    parser = argparse.ArgumentParser(description=desc)
+
+    parser.add_argument("--output_path", type=str, required=True,
+                        help="Path to the destination Zarr archive.")
+    parser.add_argument('-s', "--start_date", default='2020-01-01',
+                        help='Start date, iso format string.')
+    parser.add_argument('-e', "--end_date", default='2020-01-02',
+                        help='End date, iso format string.')
+    parser.add_argument("--pressure_levels_group", type=str, default="weatherbench_13",
+                        help="Group label for the set of pressure levels to use.")
+    parser.add_argument("--init_date", type=str, default='1900-01-01',
+                        help="Date to initialize the zarr store.")
+
+    return parser.parse_known_args()
+
+known_args, pipeline_args = parse_arguments("Update Data Slice")
+
+with beam.Pipeline(argv=pipeline_args) as p:
+    path = (
+        p
+        | "CreateDayIterator" >> beam.Create(daily_date_iterator(known_args.start_date, known_args.end_date))
+        | "LoadDataForDay" >> beam.ParDo(LoadTemporalDataForDateDoFn(data_path=GCP_DIRECTORY, start_date=known_args.init_date, pressure_levels_group=known_args.pressure_levels_group))
+        | "UpdateSlice" >> ARUpdateSlice(target=known_args.output_path, init_date=known_args.init_date)
+    )

--- a/src/update-ar-data.py
+++ b/src/update-ar-data.py
@@ -1,7 +1,12 @@
 import apache_beam as beam
-from arco_era5 import daily_date_iterator, LoadTemporalDataForDateDoFn, GCP_DIRECTORY, ARUpdateSlice
-import logging
+from arco_era5 import (
+    daily_date_iterator, 
+    LoadTemporalDataForDateDoFn, 
+    GCP_DIRECTORY, 
+    ARUpdateSlice,
+)
 import argparse
+import logging
 from typing import Tuple, List
 
 logging.getLogger().setLevel(logging.INFO)

--- a/src/update-co-data.py
+++ b/src/update-co-data.py
@@ -45,8 +45,6 @@ def parse_args(desc: str) -> Tuple[argparse.Namespace, List[str]]:
 
     return parser.parse_known_args()
 
-    return parser.parse_known_args()
-
 if __name__ == '__main__':
     known_args, unknown_args = parse_args('Convert Era 5 Model Level data to Zarr')
 

--- a/src/update-co-data.py
+++ b/src/update-co-data.py
@@ -1,0 +1,86 @@
+import logging
+import datetime
+from pangeo_forge_recipes.patterns import FilePattern, ConcatDim, MergeDim
+import argparse
+import pandas as pd
+from typing import List, Tuple
+import apache_beam as beam
+from arco_era5 import GenerateOffset, COUpdateSlice, GCP_DIRECTORY
+
+logger = logging.getLogger()
+
+model_level_default_chunks = ['dve', 'tw']
+single_level_default_chunks = [
+    'cape', 'cisst', 'sfc', 'tcol',
+    # the 'soil' chunk split by variable
+    'soil_depthBelowLandLayer_istl1',
+    'soil_depthBelowLandLayer_istl2',
+    'soil_depthBelowLandLayer_istl3',
+    'soil_depthBelowLandLayer_istl4',
+    'soil_depthBelowLandLayer_stl1',
+    'soil_depthBelowLandLayer_stl2',
+    'soil_depthBelowLandLayer_stl3',
+    'soil_depthBelowLandLayer_stl4',
+    'soil_depthBelowLandLayer_swvl1',
+    'soil_depthBelowLandLayer_swvl2',
+    'soil_depthBelowLandLayer_swvl3',
+    'soil_depthBelowLandLayer_swvl4',
+    'soil_surface_tsn',
+]
+
+def parse_args(desc: str) -> Tuple[argparse.Namespace, List[str]]:
+    parser = argparse.ArgumentParser(description=desc)
+
+    parser.add_argument('output', type=str, help='Path to output Zarr in Cloud bucket.')
+    parser.add_argument('-s', '--start', required=True, help='Start date, iso format string.')
+    parser.add_argument('-e', '--end', required=True, help='End date, iso format string.')
+    parser.add_argument('-i', '--init-date', default='1900-01-01', help='Start date, iso format string.')
+    parser.add_argument('-c', '--chunks', metavar='chunks', nargs='+', default=model_level_default_chunks, help='Chunks of variables to merge together.')
+    parser.add_argument('--time-per-day', type=int, default=24, help='Timestamps Per Day.')
+
+    return parser.parse_known_args()
+
+if __name__ == '__main__':
+    logging.getLogger().setLevel(logging.INFO)
+    known_args, unknown_args = parse_args('Convert Era 5 Model Level data to Zarr')
+
+    is_single_level = "single" in known_args.output
+
+    if is_single_level:
+        if known_args.chunks == model_level_default_chunks:
+            known_args.chunks = single_level_default_chunks
+
+    date_range = [
+        ts.to_pydatetime()
+        for ts in pd.date_range(start=known_args.start,end=known_args.end, freq="MS" if is_single_level else "D").to_list()
+    ]
+
+    def model_level_make_path(time: datetime.datetime, chunk: str) -> str:
+        """Make path to Era5 data from timestamp and variable."""
+        HRES_PATH = f"{GCP_DIRECTORY}/ERA5GRIB/HRES/Daily"
+        if '_' in chunk:
+            chunk_, level, var = chunk.split('_')
+            return f"{HRES_PATH}/{time.year:04d}/{time.year:04d}{time.month:02d}{time.day:02d}_hres_{chunk_}.grb2_{level}_{var}.grib"
+        return f"{HRES_PATH}/{time.year:04d}/{time.year:04d}{time.month:02d}{time.day:02d}_hres_{chunk}.grb2"
+
+    def single_level_make_path(time: datetime.datetime, chunk: str) -> str:
+        """Make path to Era5 data from timestamp and variable."""
+        HRES_PATH = f"{GCP_DIRECTORY}/ERA5GRIB/HRES/Month"
+        if '_' in chunk:
+            chunk_, level, var = chunk.split('_')
+            return f"{HRES_PATH}/{time.year:04d}/{time.year:04d}{time.month:02d}_hres_{chunk_}.grb2_{level}_{var}.grib"
+        return f"{HRES_PATH}/{time.year:04d}/{time.year:04d}{time.month:02d}_hres_{chunk}.grb2"
+
+    date_dim = ConcatDim("time", date_range)
+    chunks_dim = MergeDim("chunk", known_args.chunks)
+    pattern = FilePattern(single_level_make_path if is_single_level else model_level_make_path, date_dim, chunks_dim, file_type='grib')
+    files = [ p[1] for p in pattern.items() ]
+    
+    with beam.Pipeline(argv=unknown_args) as p:
+        paths = (
+            p
+            | "Create" >> beam.Create(files)
+            | "GenerateOffset" >> GenerateOffset(init_date=known_args.init_date, is_single_level=is_single_level, timestamps_per_file=known_args.time_per_day)
+            | "Reshuffle" >> beam.Reshuffle()
+            | "UpdateSlice" >> COUpdateSlice(target=known_args.output)
+        )

--- a/src/update-co-data.py
+++ b/src/update-co-data.py
@@ -8,6 +8,7 @@ import apache_beam as beam
 from arco_era5 import GenerateOffset, COUpdateSlice, GCP_DIRECTORY
 
 logger = logging.getLogger()
+logger.setLevel(logging.INFO)
 
 model_level_default_chunks = ['dve', 'tw']
 single_level_default_chunks = [
@@ -41,7 +42,6 @@ def parse_args(desc: str) -> Tuple[argparse.Namespace, List[str]]:
     return parser.parse_known_args()
 
 if __name__ == '__main__':
-    logging.getLogger().setLevel(logging.INFO)
     known_args, unknown_args = parse_args('Convert Era 5 Model Level data to Zarr')
 
     is_single_level = "single" in known_args.output

--- a/src/update-co-data.py
+++ b/src/update-co-data.py
@@ -1,11 +1,8 @@
 import logging
-import datetime
-from pangeo_forge_recipes.patterns import FilePattern, ConcatDim, MergeDim
 import argparse
-import pandas as pd
 from typing import List, Tuple
 import apache_beam as beam
-from arco_era5 import GenerateOffset, COUpdateSlice, GCP_DIRECTORY
+from arco_era5 import GenerateOffset, COUpdateSlice, GCP_DIRECTORY, daily_date_iterator, generate_input_paths
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
@@ -32,49 +29,34 @@ single_level_default_chunks = [
 def parse_args(desc: str) -> Tuple[argparse.Namespace, List[str]]:
     parser = argparse.ArgumentParser(description=desc)
 
-    parser.add_argument('output', type=str, help='Path to output Zarr in Cloud bucket.')
-    parser.add_argument('-s', '--start', required=True, help='Start date, iso format string.')
-    parser.add_argument('-e', '--end', required=True, help='End date, iso format string.')
-    parser.add_argument('-i', '--init-date', default='1900-01-01', help='Start date, iso format string.')
-    parser.add_argument('-c', '--chunks', metavar='chunks', nargs='+', default=model_level_default_chunks, help='Chunks of variables to merge together.')
-    parser.add_argument('--time-per-day', type=int, default=24, help='Timestamps Per Day.')
+    parser.add_argument('--output_path', type=str, required=True,
+                        help='Path to output Zarr in Cloud bucket.')
+    parser.add_argument('-s', '--start_date', required=True,
+                        help='Start date, iso format string.')
+    parser.add_argument('-e', '--end_date', required=True,
+                        help='End date, iso format string.')
+    parser.add_argument('-i', '--init_date', default='1900-01-01',
+                        help='Start date, iso format string.')
+    parser.add_argument('-c', '--chunks', metavar='chunks', nargs='+',
+                        default=model_level_default_chunks,
+                        help='Chunks of variables to merge together.')
+    parser.add_argument('--time_per_day', type=int, default=24,
+                        help='Timestamps Per Day.')
+
+    return parser.parse_known_args()
 
     return parser.parse_known_args()
 
 if __name__ == '__main__':
     known_args, unknown_args = parse_args('Convert Era 5 Model Level data to Zarr')
 
-    is_single_level = "single" in known_args.output
+    is_single_level = "single" in known_args.output_path
 
     if is_single_level:
         if known_args.chunks == model_level_default_chunks:
             known_args.chunks = single_level_default_chunks
 
-    date_range = [
-        ts.to_pydatetime()
-        for ts in pd.date_range(start=known_args.start,end=known_args.end, freq="MS" if is_single_level else "D").to_list()
-    ]
-
-    def model_level_make_path(time: datetime.datetime, chunk: str) -> str:
-        """Make path to Era5 data from timestamp and variable."""
-        HRES_PATH = f"{GCP_DIRECTORY}/ERA5GRIB/HRES/Daily"
-        if '_' in chunk:
-            chunk_, level, var = chunk.split('_')
-            return f"{HRES_PATH}/{time.year:04d}/{time.year:04d}{time.month:02d}{time.day:02d}_hres_{chunk_}.grb2_{level}_{var}.grib"
-        return f"{HRES_PATH}/{time.year:04d}/{time.year:04d}{time.month:02d}{time.day:02d}_hres_{chunk}.grb2"
-
-    def single_level_make_path(time: datetime.datetime, chunk: str) -> str:
-        """Make path to Era5 data from timestamp and variable."""
-        HRES_PATH = f"{GCP_DIRECTORY}/ERA5GRIB/HRES/Month"
-        if '_' in chunk:
-            chunk_, level, var = chunk.split('_')
-            return f"{HRES_PATH}/{time.year:04d}/{time.year:04d}{time.month:02d}_hres_{chunk_}.grb2_{level}_{var}.grib"
-        return f"{HRES_PATH}/{time.year:04d}/{time.year:04d}{time.month:02d}_hres_{chunk}.grb2"
-
-    date_dim = ConcatDim("time", date_range)
-    chunks_dim = MergeDim("chunk", known_args.chunks)
-    pattern = FilePattern(single_level_make_path if is_single_level else model_level_make_path, date_dim, chunks_dim, file_type='grib')
-    files = [ p[1] for p in pattern.items() ]
+    files = generate_input_paths(known_args.start_date, known_args.end_date, GCP_DIRECTORY, known_args.chunks, is_single_level=is_single_level)
     
     with beam.Pipeline(argv=unknown_args) as p:
         paths = (
@@ -82,5 +64,5 @@ if __name__ == '__main__':
             | "Create" >> beam.Create(files)
             | "GenerateOffset" >> GenerateOffset(init_date=known_args.init_date, is_single_level=is_single_level, timestamps_per_file=known_args.time_per_day)
             | "Reshuffle" >> beam.Reshuffle()
-            | "UpdateSlice" >> COUpdateSlice(target=known_args.output)
+            | "UpdateSlice" >> COUpdateSlice(target=known_args.output_path)
         )


### PR DESCRIPTION
Here are some changes in the current script to initialize the `zarr` store from some specific date and a script to seed the data later on in the dataset.

## Analysis Ready

Change Includes
- Added some new arguments to the `netcdf_to_zarr` script. `--init_date`, `--from_init_date` and `--only_initialize_store`.
- Removed `--temp_location` from arguments as the pipeline is ignoring it while running on `DataflowRunner`.
- Added a script to seed data in the `zarr` array itself without involving the `xarray` layer and chunking scheme.
- Moved some functions to `source_data.py` from `netcdf_to_zarr.py` as it's reused in the data seeding script.

`netcdf_to_zarr` script can now be used in three different ways.
- Initialize stores from `start_date` to `end_date` and write chunks. (Current flow)
- Initialize stores from `init_date` to `end_date` and write chunks from `start_date` to `end_date`. The other values which are falling beyond the range of `start_date` and `end_date` will remain `nans`. (Required `--from_init_date` and optional `--init_date`.)
- Only Initialize the store and not seed data right now. As it can be done via a different script `update_data.py`. (Required `--only_initialize_store` and optional `--init_date`)

Some defaults
- By default the script will run the same as before. 
- For initialization the default `init_date` will be `1900-01-01`. Can be changed via `--init_date` arg.
- By default It'll initialize and start seeding the data, that behavior can be altered via `--only_initialize_store` which will only create stores and not write data.

## Cloud Optimized
- The data can be back filled using `update-co.py` script. Default init_date will be `1900-01-01` for all the datasets. Can be changed using the `--init_date` argument.
- Other arguments remain the same as `model-levels-to-zarr.py` or `single-levels-to-zarr.py`.
- `model` and `single` level will be interpreted from the output file name.