### PR TITLE
Remove inclusive from the source_data.

### DIFF
--- a/src/arco_era5/source_data.py
+++ b/src/arco_era5/source_data.py
@@ -543,7 +543,7 @@ def daily_date_iterator(start_date: str, end_date: str
         Year: 2023, Month: 9, Day: 4
         Year: 2023, Month: 9, Day: 5
     """
-    date_range = pd.date_range(start=start_date, end=end_date, inclusive='left')
+    date_range = pd.date_range(start=start_date, end=end_date)
     for date in date_range:
         yield date.year, date.month, date.day
 


### PR DESCRIPTION
Remove `inclusive=left` from the `daily_date_iterator` function of the `source_data.py` file. This will fixed the issue #78.

Reason: while running the script on the monthly basis this didn't include the last date of the month due to the `inclusive=left` so after removing this it will added the last day's data, too.