### PR TITLE
Fixed: Race condition when resizing existing datasets.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ to provide transparency in the provenance of all data.
 | `$BUCKET/co/`  | Cloud Optimized | A port of gaussian-gridded ERA5 data to Zarr.                                 |
 | `$BUCKET/raw/` | Raw Data        | All raw grib & NetCDF data.                                                   |  
 
-Files are updated from ECMWF on a monthly cadence (on roughly the 9th of each month) with a 3 month delay, which avoids including preliminary versions of ERA5. The date of the latest available data can be found by inspecting the "time" axis of each Zarr store.
+ - Files are updated from ECMWF on a **monthly cadence** (on roughly the 9th of each month) with a 3 month delay, which avoids including preliminary versions of ERA5.
+ - The most recent data available can be found by examining the metadata associated with each Zarr store. The metadata encompasses three essential attributes: `valid_time_start`, `valid_time_end`, and `last_updated`. These attributes specify the start date, end date, and most recent time of update for the dataset's data, respectively.
 
 ## Analysis Ready Data
 
@@ -67,11 +68,12 @@ It is a superset of the data used to train [GraphCast](https://github.com/google
 ```python
 import xarray
 
-ar_full_37_1h = xarray.open_zarr(
+ds = xarray.open_zarr(
     'gs://gcp-public-data-arco-era5/ar/full_37-1h-0p25deg-chunk-1.zarr-v3',
     chunks=None,
     storage_options=dict(token='anon'),
 )
+ar_full_37_1h = ds.sel(time=slice(ds.attrs['valid_time_start'], ds.attrs['valid_time_end']))
 ```
 
 * _Times_: `00/to/23`
@@ -370,20 +372,23 @@ This dataset contains 3D fields at 0.25° resolution with ERA5's [native vertica
 ```python
 import xarray
 
-ar_native_vertical_grid_data = xarray.open_zarr(
+ds = xarray.open_zarr(
     'gs://gcp-public-data-arco-era5/ar/model-level-1h-0p25deg.zarr-v1',
     chunks=None,
     storage_options=dict(token='anon'),
 )
+ar_native_vertical_grid_data = ds.sel(time=slice(ds.attrs['valid_time_start'], ds.attrs['valid_time_end']))
 ```
 
 It can combined with surface-level variables from the 0.25° pressure- and surface-level dataset:
 ```python
-ar_full_37_1h = xarray.open_zarr(
+ds = xarray.open_zarr(
     'gs://gcp-public-data-arco-era5/ar/full_37-1h-0p25deg-chunk-1.zarr-v3',
     chunks=None,
     storage_options=dict(token='anon'),
 )
+ar_full_37_1h = ds.sel(time=slice(ds.attrs['valid_time_start'], ds.attrs['valid_time_end']))
+
 ar_model_level_and_surface_data = xarray.merge([
     ar_native_vertical_grid_data, ar_full_37_1h.drop_dims('level')
 ])
@@ -433,11 +438,12 @@ This dataset contains model-level wind fields on ERA5's native grid, as spherica
 ```python
 import xarray
 
-model_level_wind = xarray.open_zarr(
+ds = xarray.open_zarr(
     'gs://gcp-public-data-arco-era5/co/model-level-wind.zarr-v2',
     chunks=None,
     storage_options=dict(token='anon'),
 )
+model_level_wind = ds.sel(time=slice(ds.attrs['valid_time_start'], ds.attrs['valid_time_end']))
 ```
 
 * _Levels_: `1/to/137`
@@ -468,11 +474,12 @@ This dataset contains model-level moisture fields on ERA5's native reduced Gauss
 ```python
 import xarray
 
-model_level_moisture = xr.open_zarr(
+ds = xr.open_zarr(
     'gs://gcp-public-data-arco-era5/co/model-level-moisture.zarr-v2/',
     chunks=None,
     storage_options=dict(token='anon'),
 )
+model_level_moisture = ds.sel(time=slice(ds.attrs['valid_time_start'], ds.attrs['valid_time_end']))
 ```
 
 * _Levels_: `1/to/137`
@@ -507,11 +514,12 @@ This dataset contains single-level renanalysis fields on ERA5's native grid, as 
 ```python
 import xarray
 
-single_level_surface = xarray.open_zarr(
+ds = xarray.open_zarr(
     'gs://gcp-public-data-arco-era5/co/single-level-surface.zarr-v2/',
     chunks=None,
     storage_options=dict(token='anon'),
 )
+single_level_surface = ds.sel(time=slice(ds.attrs['valid_time_start'], ds.attrs['valid_time_end']))
 ```
 
 * _Times_: `00/to/23`
@@ -540,11 +548,12 @@ This dataset contains single-level renanalysis fields on ERA5's native reduced G
 ```python
 import xarray
 
-single_level_reanalysis = xarray.open_zarr(
+ds = xarray.open_zarr(
     'gs://gcp-public-data-arco-era5/co/single-level-reanalysis.zarr-v2',
     chunks=None,
     storage_options=dict(token='anon'),
 )
+single_level_reanalysis = ds.sel(time=slice(ds.attrs['valid_time_start'], ds.attrs['valid_time_end']))
 ```
 
 * _Times_: `00/to/23`
@@ -610,11 +619,12 @@ This dataset contains single-level forecast fields on ERA5's native reduced Gaus
 ```python
 import xarray
 
-single_level_forecasts = xarray.open_zarr(
+ds = xarray.open_zarr(
     'gs://gcp-public-data-arco-era5/co/single-level-forecast.zarr-v2/', 
     chunks=None,
     storage_options=dict(token='anon'),
 )
+single_level_forecasts = ds.sel(time=slice(ds.attrs['valid_time_start'], ds.attrs['valid_time_end']))
 ```
 
 * _Times_: `06:00/18:00`

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ to provide transparency in the provenance of all data.
 | `$BUCKET/raw/` | Raw Data        | All raw grib & NetCDF data.                                                   |  
 
  - Files are updated from ECMWF on a **monthly cadence** (on roughly the 9th of each month) with a 3 month delay, which avoids including preliminary versions of ERA5.
- - The most recent data available can be found by examining the metadata associated with each Zarr store. The metadata encompasses three essential attributes: `valid_time_start`, `valid_time_end`, and `last_updated`. These attributes specify the start date, end date, and most recent time of update for the dataset's data, respectively.Please note that both start and end times are inclusive, and all times are given in UTC.
+ - The most recent data available can be found by examining the metadata associated with each Zarr store. The metadata encompasses three essential attributes: `valid_time_start`, `valid_time_stop`, and `last_updated`. These attributes specify the start date, stop date, and most recent time of update for the dataset's data, respectively. Please note that both start and end times are inclusive, and all times are given in UTC.
 
 ## Analysis Ready Data
 
@@ -73,7 +73,7 @@ ds = xarray.open_zarr(
     chunks=None,
     storage_options=dict(token='anon'),
 )
-ar_full_37_1h = ds.sel(time=slice(ds.attrs['valid_time_start'], ds.attrs['valid_time_end']))
+ar_full_37_1h = ds.sel(time=slice(ds.attrs['valid_time_start'], ds.attrs['valid_time_stop']))
 ```
 
 * _Times_: `00/to/23`
@@ -377,7 +377,7 @@ ds = xarray.open_zarr(
     chunks=None,
     storage_options=dict(token='anon'),
 )
-ar_native_vertical_grid_data = ds.sel(time=slice(ds.attrs['valid_time_start'], ds.attrs['valid_time_end']))
+ar_native_vertical_grid_data = ds.sel(time=slice(ds.attrs['valid_time_start'], ds.attrs['valid_time_stop']))
 ```
 
 It can combined with surface-level variables from the 0.25° pressure- and surface-level dataset:
@@ -387,7 +387,7 @@ ds = xarray.open_zarr(
     chunks=None,
     storage_options=dict(token='anon'),
 )
-ar_full_37_1h = ds.sel(time=slice(ds.attrs['valid_time_start'], ds.attrs['valid_time_end']))
+ar_full_37_1h = ds.sel(time=slice(ds.attrs['valid_time_start'], ds.attrs['valid_time_stop']))
 
 ar_model_level_and_surface_data = xarray.merge([
     ar_native_vertical_grid_data, ar_full_37_1h.drop_dims('level')
@@ -443,7 +443,7 @@ ds = xarray.open_zarr(
     chunks=None,
     storage_options=dict(token='anon'),
 )
-model_level_wind = ds.sel(time=slice(ds.attrs['valid_time_start'], ds.attrs['valid_time_end']))
+model_level_wind = ds.sel(time=slice(ds.attrs['valid_time_start'], ds.attrs['valid_time_stop']))
 ```
 
 * _Levels_: `1/to/137`
@@ -479,7 +479,7 @@ ds = xr.open_zarr(
     chunks=None,
     storage_options=dict(token='anon'),
 )
-model_level_moisture = ds.sel(time=slice(ds.attrs['valid_time_start'], ds.attrs['valid_time_end']))
+model_level_moisture = ds.sel(time=slice(ds.attrs['valid_time_start'], ds.attrs['valid_time_stop']))
 ```
 
 * _Levels_: `1/to/137`
@@ -519,7 +519,7 @@ ds = xarray.open_zarr(
     chunks=None,
     storage_options=dict(token='anon'),
 )
-single_level_surface = ds.sel(time=slice(ds.attrs['valid_time_start'], ds.attrs['valid_time_end']))
+single_level_surface = ds.sel(time=slice(ds.attrs['valid_time_start'], ds.attrs['valid_time_stop']))
 ```
 
 * _Times_: `00/to/23`
@@ -553,7 +553,7 @@ ds = xarray.open_zarr(
     chunks=None,
     storage_options=dict(token='anon'),
 )
-single_level_reanalysis = ds.sel(time=slice(ds.attrs['valid_time_start'], ds.attrs['valid_time_end']))
+single_level_reanalysis = ds.sel(time=slice(ds.attrs['valid_time_start'], ds.attrs['valid_time_stop']))
 ```
 
 * _Times_: `00/to/23`
@@ -624,7 +624,7 @@ ds = xarray.open_zarr(
     chunks=None,
     storage_options=dict(token='anon'),
 )
-single_level_forecasts = ds.sel(time=slice(ds.attrs['valid_time_start'], ds.attrs['valid_time_end']))
+single_level_forecasts = ds.sel(time=slice(ds.attrs['valid_time_start'], ds.attrs['valid_time_stop']))
 ```
 
 * _Times_: `06:00/18:00`

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ to provide transparency in the provenance of all data.
 | `$BUCKET/raw/` | Raw Data        | All raw grib & NetCDF data.                                                   |  
 
  - Files are updated from ECMWF on a **monthly cadence** (on roughly the 9th of each month) with a 3 month delay, which avoids including preliminary versions of ERA5.
- - The most recent data available can be found by examining the metadata associated with each Zarr store. The metadata encompasses three essential attributes: `valid_time_start`, `valid_time_end`, and `last_updated`. These attributes specify the start date, end date, and most recent time of update for the dataset's data, respectively.
+ - The most recent data available can be found by examining the metadata associated with each Zarr store. The metadata encompasses three essential attributes: `valid_time_start`, `valid_time_end`, and `last_updated`. These attributes specify the start date, end date, and most recent time of update for the dataset's data, respectively.Please note that both start and end times are inclusive, and all times are given in UTC.
 
 ## Analysis Ready Data
 

--- a/src/arco_era5/__init__.py
+++ b/src/arco_era5/__init__.py
@@ -15,7 +15,7 @@ from .constant import variables_full_names, zarr_files
 from .data_availability import check_data_availability
 from .ingest_data_in_zarr import ingest_data_in_zarr_dataflow_job
 from .pangeo import run, parse_args
-from .resize_zarr import resize_zarr_target
+from .resize_zarr import resize_zarr_target, update_zarr_metadata
 from .source_data import (
     GCP_DIRECTORY,
     SINGLE_LEVEL_VARIABLES,

--- a/src/arco_era5/resize_zarr.py
+++ b/src/arco_era5/resize_zarr.py
@@ -147,3 +147,33 @@ def resize_zarr_target(target_store: str, end_date: datetime, init_date: str,
         logger.info(f"Consolidation of {target_store} is completed.")
     else:
         logger.info(f"Data is already resized for {target_store}.")
+
+
+def update_zarr_metadata(url: str, time_end: datetime.date, metadata_key: str = '.zmetadata') -> None:
+    try:
+        attrs = {"valid_time_start": "1940-01-01",
+                 "valid_time_end": str(time_end),
+                 "last_updated": str(datetime.datetime.now())
+                 }
+        root_group = zarr.open(url)
+
+        # update zarr_store/.zattrs file.
+        for k,v in attrs.items():
+            root_group.attrs[k] = v
+
+        # update zarr_store/.zmetadata file.
+        metadata_path = f"{url}/{metadata_key}"
+        fs = GCSFileSystem()
+        with fs.open(metadata_path) as f:
+            meta_str = f.read().decode()
+            meta = json.loads(meta_str)
+
+            existing_attrs = meta['metadata'].get('.zattrs')
+            existing_attrs.update(attrs)
+            meta['metadata']['.zattrs'] = existing_attrs
+            new_meta_str = json.dumps(meta)
+
+            fs.write_text(metadata_path, new_meta_str)
+            logging.info(f"Metadata successfully updated for {url}.")
+    except Exception as e:
+        logging.error(f"Failed to update metadata for {url}: {e}")

--- a/src/arco_era5/resize_zarr.py
+++ b/src/arco_era5/resize_zarr.py
@@ -152,14 +152,13 @@ def resize_zarr_target(target_store: str, end_date: datetime, init_date: str,
 def update_zarr_metadata(url: str, time_end: datetime.date, metadata_key: str = '.zmetadata') -> None:
     try:
         attrs = {"valid_time_start": "1940-01-01",
-                 "valid_time_end": str(time_end),
-                 "last_updated": str(datetime.datetime.now())
+                 "valid_time_stop": str(time_end),
+                 "last_updated": str(datetime.datetime.utcnow())
                  }
         root_group = zarr.open(url)
 
         # update zarr_store/.zattrs file.
-        for k,v in attrs.items():
-            root_group.attrs[k] = v
+        root_group.attrs.update(attrs)
 
         # update zarr_store/.zmetadata file.
         metadata_path = f"{url}/{metadata_key}"

--- a/src/raw-to-zarr-to-bq.py
+++ b/src/raw-to-zarr-to-bq.py
@@ -27,7 +27,7 @@ from arco_era5 import (
     parse_arguments_raw_to_zarr_to_bq,
     remove_licenses_from_directory,
     replace_non_alphanumeric_with_hyphen,
-    resize_zarr_target,
+    update_zarr_metadata,
     subprocess_run,
     update_config_file,
     )
@@ -133,13 +133,13 @@ def perform_data_operations(z_file: str, table: str, region: str, start_date: st
                             end_date: str, init_date: str):
     # Function to process a single pair of z_file and table
     try:
-        logger.info(f"Resizing zarr file: {z_file} started.")
-        resize_zarr_target(z_file, end_date, init_date)
-        logger.info(f"Resizing zarr file: {z_file} completed.")
         logger.info(f"Data ingesting for {z_file} is started.")
         ingest_data_in_zarr_dataflow_job(z_file, region, start_date, end_date, init_date,
                                          project=PROJECT, bucket=BUCKET, python_path=PYTHON_PATH)
         logger.info(f"Data ingesting for {z_file} is completed.")
+        logger.info(f"update metadata for zarr file: {z_file} started.")
+        update_zarr_metadata(z_file, end_date)
+        logger.info(f"update metadata for zarr file: {z_file} completed.")
         start = f' "start_date": "{start_date}" '
         end = f'"end_date": "{end_date}" '
         zarr_kwargs = "'{" + f'{start},{end}' + "}'"


### PR DESCRIPTION
I have updated all datasets by resizing to `2050-12-31`. Additionally, I added three new attributes— `valid_time_start, valid_time_end, and last_updated` to each Zarr store. These attributes provide essential information, such as the validity period of the data and the timestamp of the most recent update. These changes enhance the dataset's metadata and improve its usability, and fixed issue #81.