### PR TITLE
Update format of data downloading for NetCDF type.

### DIFF
--- a/raw/era5_pl_hourly.cfg
+++ b/raw/era5_pl_hourly.cfg
@@ -33,7 +33,7 @@ partition_keys=
 
 [selection]
 product_type=reanalysis
-format=netcdf
+format=netcdf_legacy
 
 # See go/ecmwf-grids
 grid=0.25/0.25

--- a/raw/era5_sl_hourly.cfg
+++ b/raw/era5_sl_hourly.cfg
@@ -32,7 +32,7 @@ partition_keys=
 
 [selection]
 product_type=reanalysis
-format=netcdf
+format=netcdf_legacy
 
 # See go/ecmwf-grids
 grid=0.25/0.25


### PR DESCRIPTION
As `cds` is moved to [`cds-beta`](https://forum.ecmwf.int/t/the-new-climate-data-store-beta-cds-beta-is-now-live/3315) the new **NetCDF** data coming from the `cds-beta` is not matched with the old data. I already raised the issue for the same in [forum](https://forum.ecmwf.int/t/differences-in-era5-pressure-level-data-between-cds-and-cds-beta/5014) but don't get the reply from there.

I found the solution for the above which is working as of now.

Reproducing code:
```
import cdsapi
client = cdsapi.Client(url="https://cds.climate.copernicus.eu/api", key="NEW_CDS_BETA_KEY")

dataset = 'reanalysis-era5-pressure-levels'
request =  {'product_type': 'reanalysis', 'format': 'netcdf', 'grid': ['0.25', '0.25'], 'date': ['2024-05-05'],
'time': ['00', '01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12', '13', '14', '15', '16', '17',
'18', '19', '20', '21', '22', '23'], 'variable': ['geopotential'], 'pressure_level': ['1']}
target = 'all_data/download_new1.nc'

result = client.retrieve(dataset, request, target)
```

```
import cdsapi
client = cdsapi.Client(url="https://cds.climate.copernicus.eu/api/v2", key="OLD_CDS_KEY")

dataset = 'reanalysis-era5-pressure-levels'
request =  {'product_type': 'reanalysis', 'format': 'netcdf', 'grid': ['0.25', '0.25'], 'date': ['2024-05-05'],
'time': ['00', '01', '02', '03', '04', '05', '06', '07', '08', '09', '10', '11', '12', '13', '14', '15', '16', '17',
'18', '19', '20', '21', '22', '23'], 'variable': ['geopotential'], 'pressure_level': ['1']}
target = 'all_data/download_old.nc'
result = client.retrieve(dataset, request, target)
```

Data from the above both code is not same but when you pass the `netcdf_legacy` instead of `netcdf` in `first code` it returns the same data with 2nd code.