### PR TITLE
Update sanity job to support start_date and end_date from the CLI

### DIFF
--- a/src/arco_era5/resize_zarr.py
+++ b/src/arco_era5/resize_zarr.py
@@ -149,7 +149,7 @@ def resize_zarr_target(target_store: str, end_date: datetime, init_date: str,
         logger.info(f"Data is already resized for {target_store}.")
 
 
-def update_zarr_metadata(url: str, time_end: datetime.date, mode: str, metadata_key: str = '.zmetadata') -> None:
+def update_zarr_metadata(url: str, time_end: str, mode: str, metadata_key: str = '.zmetadata') -> None:
     try:
         attrs = {
             "valid_time_start": "1940-01-01",

--- a/src/arco_era5/sanity.py
+++ b/src/arco_era5/sanity.py
@@ -204,7 +204,7 @@ def generate_override_args(
     ]
     return args
 
-def run_sanity_job(target_path: str, temp_path: str, init_date: str):
+def run_sanity_job(target_path: str, temp_path: str, init_date: str, start_date: str, end_date: str):
     """Trigger job for era5 data sanity."""
 
     target_name = target_path.split('/')[-1].split('.')[0]
@@ -215,6 +215,8 @@ def run_sanity_job(target_path: str, temp_path: str, init_date: str):
     )
 
     override_args.extend(['--sdk_container_image', ARCO_ERA5_SDK_CONTAINER_IMAGE,'--save_main_session'])
+
+    override_args.extend(['--start_date', start_date, '--end_date', end_date])
 
     if target_name in HARNESS_THREADS:
         override_args.extend(['--number_of_worker_harness_threads', str(HARNESS_THREADS[target_name])])

--- a/src/arco_era5/update_config_files.py
+++ b/src/arco_era5/update_config_files.py
@@ -190,7 +190,7 @@ def generate_additional_content() -> str:
     return additional_content
 
 
-def update_config_file(directory: str, field_name: str,
+def update_config_file(directory: str, field_name: str, dates_data: MonthDates,
                        mode: str, temp_path: str = None) -> None:
     """Update the configuration files in the specified directory.
 
@@ -200,7 +200,6 @@ def update_config_file(directory: str, field_name: str,
         additional_content (str): The additional content to be added under the
                     '[selection]' section.
     """
-    dates_data = get_previous_month_dates(mode)
     config_args = {
         "first_day": dates_data['first_day'],
         "last_day": dates_data['last_day'],

--- a/src/era5-sanity.py
+++ b/src/era5-sanity.py
@@ -39,6 +39,10 @@ def parse_arguments(desc: str) -> t.Tuple[argparse.Namespace,
                         help='Start date, iso format string.')
     parser.add_argument('--timestamps_per_day', type=int, default=24,
                         help='Timestamps Per Day.')
+    parser.add_argument('--start_date', type=str, required=True,
+                        help='Start Date')
+    parser.add_argument('--end_date', type=str, required=True,
+                        help='End Date')
 
     return parser.parse_known_args()
 
@@ -50,13 +54,11 @@ if __name__ == "__main__":
     is_single_level = "single-level" in parsed_args.target_path
     is_analysis_ready = "/ar/" in parsed_args.target_path
 
-    dates = get_previous_month_dates("era5")
-
     original_paths = generate_raw_paths(
-        dates['first_day'], dates['last_day'], parsed_args.target_path, is_single_level, is_analysis_ready
+        parsed_args.start_date, parsed_args.end_date, parsed_args.target_path, is_single_level, is_analysis_ready
     )
     temp_paths = generate_raw_paths(
-        dates['first_day'], dates['last_day'], parsed_args.target_path, is_single_level, is_analysis_ready, parsed_args.temp_path
+        parsed_args.start_date, parsed_args.end_date, parsed_args.target_path, is_single_level, is_analysis_ready, parsed_args.temp_path
     )
 
     input_paths = [(original_path, temp_path) for original_path, temp_path in zip(original_paths, temp_paths)]
@@ -75,6 +77,6 @@ if __name__ == "__main__":
             ))
         )
     
-    update_zarr_metadata(parsed_args.target_path, dates['last_day'], mode=ExecTypes.ERA5.value)
+    update_zarr_metadata(parsed_args.target_path, parsed_args.end_date, mode=ExecTypes.ERA5.value)
 
-    update_splittable_files(dates['first_day'].strftime("%Y/%m"), parsed_args.temp_path, target_path=parsed_args.target_path)
+    update_splittable_files(parsed_args.start_date.rsplit('-', 1)[0], parsed_args.temp_path, target_path=parsed_args.target_path)

--- a/src/raw-to-zarr-to-bq.py
+++ b/src/raw-to-zarr-to-bq.py
@@ -78,7 +78,7 @@ def start_data_ingestion(zarr_files_to_process: t.List[str], first_day: datetime
     with ThreadPoolExecutor(max_workers=8) as tp:
         for z_file in zarr_files_to_process:
             if parsed_args.mode == ExecTypes.ERA5.value:
-                tp.submit(run_sanity_job, z_file, TEMP_PATH_FOR_RAW_DATA, parsed_args.init_date)
+                tp.submit(run_sanity_job, z_file, TEMP_PATH_FOR_RAW_DATA, parsed_args.init_date, first_day, last_day)
             else:
                 tp.submit(perform_data_operations, z_file, first_day, last_day, init_date, mode)
 
@@ -96,7 +96,7 @@ if __name__ == "__main__":
 
         logger.info("Config file updation started.")
         temp_path = TEMP_PATH_FOR_RAW_DATA if parsed_args.mode == ExecTypes.ERA5.value else None
-        update_config_file(DIRECTORY, FIELD_NAME, parsed_args.mode, temp_path)
+        update_config_file(DIRECTORY, FIELD_NAME, dates_data, parsed_args.mode, temp_path)
         logger.info("Config file updation completed.")
 
         root_path = TEMP_PATH_FOR_RAW_DATA if parsed_args.mode == ExecTypes.ERA5.value else ROOT_PATH


### PR DESCRIPTION
Before - The time range was calculated from the code itself. So we cannot control that.
After - We can run the sanity for any time range after this.

update_config_files module should also use the dates defined at the start of the job. 