### PR TITLE
Migration to new netCDF for pl and sl era5 data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ docs/.ipynb_checkpoints/
 *.egg-info
 env/
 venv/
+.vscode

--- a/raw/daily/era5_pl_hourly.cfg
+++ b/raw/daily/era5_pl_hourly.cfg
@@ -33,7 +33,7 @@ partition_keys=
 
 [selection]
 product_type=reanalysis
-format=netcdf_legacy
+format=netcdf
 
 # See go/ecmwf-grids
 grid=0.25/0.25

--- a/raw/daily/era5_sl_hourly.cfg
+++ b/raw/daily/era5_sl_hourly.cfg
@@ -32,7 +32,7 @@ partition_keys=
 
 [selection]
 product_type=reanalysis
-format=netcdf_legacy
+format=netcdf
 
 # See go/ecmwf-grids
 grid=0.25/0.25

--- a/src/arco_era5/__init__.py
+++ b/src/arco_era5/__init__.py
@@ -11,6 +11,14 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import fsspec.asyn
+# Initialize the fsspec event loop on the main thread to avoid signal handling issues
+# when fsspec is used within worker threads (e.g. in Apache Beam / Dataflow).
+try:
+    fsspec.asyn.get_loop()
+except Exception:
+    pass
+
 from .constant import ARCO_ERA5_ZARR_FILES, variables_full_names, zarr_files
 from .data_availability import check_data_availability
 from .download import raw_data_download_dataflow_job, data_splitting_dataflow_job

--- a/src/arco_era5/sanity.py
+++ b/src/arco_era5/sanity.py
@@ -63,6 +63,9 @@ def parse_ar_url(url: str, init_date: str):
     time_offset_start = offset_along_time_axis(init_date, int(year), int(month), int(day))
     time_offset_end = time_offset_start + HOURS_PER_DAY
     if file_name == "surface.nc":
+        # ERA5 uses "geopotential" for file names for both the static "geopotential"
+        # feature at surface, and the dynamic multilevel "geopotential". To avoid this
+        # clash, we will always rename the static one to "geopotential_at_surface".
         if variable == "geopotential":
             variable = "geopotential_at_surface"
         return (slice(time_offset_start, time_offset_end),), variable
@@ -85,7 +88,7 @@ def add_sanity_files(path: str, data_changed: bool):
 def replace_and_remove_file(path1: str, path2: str, data_changed: bool):
     """Replace root with latest era5 file and remove temp file"""
     logger.info(f"Replacing {path1} with {path2}.")
-    copy(path2, path1, to_local=False)
+    copy(path2, path1)
     logger.info(f"Creating sentinel files.")
     add_sanity_files(path1, data_changed)
     logger.info(f"Removing temporary file {path2}.")
@@ -100,13 +103,13 @@ def combine_expver(ds: xr.Dataset):
 def open_dataset(path: str):
     """Open xarray dataset."""
     try:
-        ds = xr.open_dataset(path, engine="h5netcdf" if ".nc" in path else "cfgrib").load()
+        ds = xr.open_dataset(path, engine="h5netcdf" if ".nc" in path else "cfgrib")
     except Exception as e:
-        ds = xr.open_dataset(path, engine="scipy").load()
-    ds = ds.squeeze().drop(['number', 'step', 'pressure_level', 'surface', 'expver'], errors="ignore")
+        ds = xr.open_dataset(path, engine="scipy")
+    ds = ds.squeeze().drop_vars(['number', 'step', 'pressure_level', 'surface', 'expver'], errors="ignore")
     if "valid_time" in ds.dims:
         ds = ds.rename({ 'valid_time': 'time' })
-    return ds
+    return ds.load()
 
 class OpenLocal(beam.DoFn):
     """class to open raw files and compare the data."""

--- a/src/arco_era5/sanity.py
+++ b/src/arco_era5/sanity.py
@@ -21,7 +21,7 @@ import typing as t
 import xarray as xr
 
 from dataclasses import dataclass
-from gcsfs import GCSFileSystem
+from apache_beam.io.filesystems import FileSystems
 
 from .data_availability import generate_input_paths_ar
 from .download import SPLITTING_DATASETS
@@ -46,8 +46,6 @@ HARNESS_THREADS = {
     'model-level-wind': 4
 }
 
-fs = GCSFileSystem()
-
 
 def generate_raw_paths(start_date: str, end_date: str, target_path: str, is_single_level: bool, is_analysis_ready: bool, root_path: str = GCP_DIRECTORY):
     """Generate raw input paths."""
@@ -65,6 +63,8 @@ def parse_ar_url(url: str, init_date: str):
     time_offset_start = offset_along_time_axis(init_date, int(year), int(month), int(day))
     time_offset_end = time_offset_start + HOURS_PER_DAY
     if file_name == "surface.nc":
+        if variable == "geopotential":
+            variable = "geopotential_at_surface"
         return (slice(time_offset_start, time_offset_end),), variable
     else:
         level = int(file_name.split(".")[0])
@@ -75,16 +75,17 @@ def add_sanity_files(path: str, data_changed: bool):
     dir_path, file_name = path.rsplit("/", 1)
 
     success_file = f"{dir_path}/{file_name.rsplit('.', 1)[0]}_ratified"
-    fs = GCSFileSystem()
-    fs.write_text(success_file, '')
+    with FileSystems.create(success_file) as f:
+        f.write(b'')
     if data_changed:
         data_change_file = f"{dir_path}/{file_name.rsplit('.', 1)[0]}_data_changed"
-        fs.write_text(data_change_file, '')
+        with FileSystems.create(data_change_file) as f:
+            f.write(b'')
 
 def replace_and_remove_file(path1: str, path2: str, data_changed: bool):
     """Replace root with latest era5 file and remove temp file"""
     logger.info(f"Replacing {path1} with {path2}.")
-    copy(path2, path1)
+    copy(path2, path1, to_local=False)
     logger.info(f"Creating sentinel files.")
     add_sanity_files(path1, data_changed)
     logger.info(f"Removing temporary file {path2}.")
@@ -98,7 +99,13 @@ def combine_expver(ds: xr.Dataset):
 
 def open_dataset(path: str):
     """Open xarray dataset."""
-    ds = xr.open_dataset(path, engine="scipy" if ".nc" in path else "cfgrib").load()
+    try:
+        ds = xr.open_dataset(path, engine="h5netcdf" if ".nc" in path else "cfgrib").load()
+    except Exception as e:
+        ds = xr.open_dataset(path, engine="scipy").load()
+    ds = ds.squeeze().drop(['number', 'step', 'pressure_level', 'surface', 'expver'], errors="ignore")
+    if "valid_time" in ds.dims:
+        ds = ds.rename({ 'valid_time': 'time' })
     return ds
 
 class OpenLocal(beam.DoFn):
@@ -108,7 +115,7 @@ class OpenLocal(beam.DoFn):
 
         path1, path2 = paths
 
-        temp_file_check = fs.exists(path2)
+        temp_file_check = FileSystems.exists(path2)
 
         if temp_file_check:
             with opener(path1) as file1:

--- a/src/arco_era5/source_data.py
+++ b/src/arco_era5/source_data.py
@@ -369,8 +369,12 @@ def _read_nc_dataset(gpath_file):
     """
     path = str(gpath_file).replace('gs:/', 'gs://')
     with fsspec.open(path, mode="rb") as fid:
-        dataset = xr.open_dataset(fid, engine="scipy", cache=False)
+        dataset = xr.open_dataset(fid, engine="h5netcdf", cache=False).load()
     # All dataset have a single data array in them, so we just return the array.
+    dataset = dataset.squeeze().drop(['number', 'step', 'pressure_level', 'surface', 'expver'], errors="ignore")
+    if "valid_time" in dataset.dims:
+        dataset = dataset.rename({ 'valid_time': 'time' })
+    logging.info(f"Total Vars: {path} {len(dataset)}")
     assert len(dataset) == 1
     dataarray = next(iter(dataset.values()))
     if "expver" in dataarray.coords:
@@ -651,10 +655,6 @@ class LoadTemporalDataForDateDoFn(beam.DoFn):
             # if something goes wrong. Note "from e" will also raise the details of the
             # original exception.
             raise RuntimeError(f"Error loading {year}-{month}-{day}") from e
-
-        # It is crucial to actually "load" as otherwise we get a pickle error.
-        single_level_vars = single_level_vars.load()
-        multilevel_vars = multilevel_vars.load()
 
         dataset = xr.merge([single_level_vars, multilevel_vars])
         dataset = align_coordinates(dataset)

--- a/src/arco_era5/source_data.py
+++ b/src/arco_era5/source_data.py
@@ -374,7 +374,6 @@ def _read_nc_dataset(gpath_file):
     dataset = dataset.squeeze().drop(['number', 'step', 'pressure_level', 'surface', 'expver'], errors="ignore")
     if "valid_time" in dataset.dims:
         dataset = dataset.rename({ 'valid_time': 'time' })
-    logging.info(f"Total Vars: {path} {len(dataset)}")
     assert len(dataset) == 1
     dataarray = next(iter(dataset.values()))
     if "expver" in dataarray.coords:

--- a/src/arco_era5/source_data.py
+++ b/src/arco_era5/source_data.py
@@ -369,11 +369,12 @@ def _read_nc_dataset(gpath_file):
     """
     path = str(gpath_file).replace('gs:/', 'gs://')
     with fsspec.open(path, mode="rb") as fid:
-        dataset = xr.open_dataset(fid, engine="h5netcdf", cache=False).load()
+        dataset = xr.open_dataset(fid, engine="h5netcdf", cache=False)
     # All dataset have a single data array in them, so we just return the array.
     dataset = dataset.squeeze().drop(['number', 'step', 'pressure_level', 'surface', 'expver'], errors="ignore")
     if "valid_time" in dataset.dims:
         dataset = dataset.rename({ 'valid_time': 'time' })
+    dataset = dataset.load()
     assert len(dataset) == 1
     dataarray = next(iter(dataset.values()))
     if "expver" in dataarray.coords:

--- a/src/arco_era5/update_config_files.py
+++ b/src/arco_era5/update_config_files.py
@@ -19,6 +19,7 @@ import json
 import logging
 import os
 import re
+import time
 import typing as t
 
 from google.cloud import secretmanager
@@ -105,6 +106,8 @@ def new_config_file(config_file: str, field_name: str, additional_content: str,
     else:
         config.set("selection", field_name,
                    f"{first_day}/to/{last_day}")
+    
+    config.set("selection", "nocache", str(int(time.time())))
 
     sections_list = additional_content.split("\n\n")
     for section in sections_list[:-1]:

--- a/src/arco_era5/utils.py
+++ b/src/arco_era5/utils.py
@@ -129,15 +129,16 @@ def parse_arguments_raw_to_zarr_to_bq(desc: str) -> t.Tuple[argparse.Namespace,
     return parser.parse_known_args()
 
 
-def copy(src: str, dst: str, to_local = True) -> None:
+def copy(src: str, dst: str) -> None:
     """A method to copy file from src to dst (supports GCS and local)."""
+    is_same_fs = src.startswith("gs://") and dst.startswith("gs://")
     try:
-        if to_local:
+        if is_same_fs:
+            FileSystems.copy([src], [dst])
+        else:
             # Cross-filesystem copy: read from src, write to dst
             with FileSystems.open(src) as f_in, FileSystems.create(dst) as f_out:
-                shutil.copyfileobj(f_in, f_out)
-        else:
-            FileSystems.copy([src], [dst])
+                shutil.copyfileobj(f_in, f_out, 1024 * 1024)
     except Exception as e:
         msg = f"Failed to copy file {src!r} to {dst!r}. Error: {e}"
         logger.error(msg)

--- a/src/arco_era5/utils.py
+++ b/src/arco_era5/utils.py
@@ -16,6 +16,7 @@ import datetime
 import logging
 import os
 import re
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -26,6 +27,7 @@ import typing as t
 from enum import Enum
 from contextlib import contextmanager
 from google.cloud import run_v2
+from apache_beam.io.filesystems import FileSystems
 
 logger = logging.getLogger(__name__)
 
@@ -127,21 +129,19 @@ def parse_arguments_raw_to_zarr_to_bq(desc: str) -> t.Tuple[argparse.Namespace,
     return parser.parse_known_args()
 
 
-def copy(src: str, dst: str) -> None:
-    """A method to copy remote file to local path.
-
-    Args:
-        src (str): The cloud storage path to the grib file.
-        dst (str): A temp location to copy the file.
-    """
-    cmd = 'gcloud storage cp'
+def copy(src: str, dst: str, to_local = True) -> None:
+    """A method to copy file from src to dst (supports GCS and local)."""
     try:
-        subprocess.run(cmd.split() + [src, dst], check=True, capture_output=True,
-                       text=True, input="n/n")
-        return
-    except subprocess.CalledProcessError as e:
-        msg = f"Failed to copy file {src!r} to {dst!r} Error {e}"
+        if to_local:
+            # Cross-filesystem copy: read from src, write to dst
+            with FileSystems.open(src) as f_in, FileSystems.create(dst) as f_out:
+                shutil.copyfileobj(f_in, f_out)
+        else:
+            FileSystems.copy([src], [dst])
+    except Exception as e:
+        msg = f"Failed to copy file {src!r} to {dst!r}. Error: {e}"
         logger.error(msg)
+        raise
 
 
 @contextmanager
@@ -160,13 +160,10 @@ def opener(fname: str) -> t.Any:
 
 
 def remove_file(url: str):
-    """Remove file from remote location."""
-    cmd = 'gcloud storage rm --recursive --continue-on-error'
+    """Remove file from remote or local location."""
     try:
-        subprocess.run(cmd.split() + [url], check=True, capture_output=True,
-                       text=True, input="n/n")
-        return
-    except subprocess.CalledProcessError as e:
+        FileSystems.delete([url])
+    except Exception as e:
         msg = f"Failed to remove file {url!r} Error {e}"
         logger.error(msg)
 


### PR DESCRIPTION
As per the discussion with the `ECMWF`  team they are no longer maintaining an old `netcdf_legacy` data format. That results in consistent issues in downloading the surface and pressure level data from the `cds` server. So we have made a migration to a new `netCDF` format. 

Some important notes from now
- The daily `ERA5t` downloads will now download new `netCDF` data. Which has already started from July 1st.
- Data for March 2026 is replaced by a new `netCDF` and the sanity has been done for the same.
- For April, May and June we'll do the sanity between old `netCDF` (`ERA5t`) and new `netCDF` (`ERA5`) for coming months and then we'll have a completely new version of `netCDF` data in the bucket. 